### PR TITLE
finish AlignmentInspector

### DIFF
--- a/packages/app/src/components/inspector/AlignmentInspector.tsx
+++ b/packages/app/src/components/inspector/AlignmentInspector.tsx
@@ -27,16 +27,20 @@ function AlignmentInspector(props: AlignmentInspectorProps) {
   const [, dispatch] = useApplicationState();
   return (
     <AlignmentInspectorContainer>
-      <SpaceEvenlyHorizontallyIcon />
-      <SpaceEvenlyVerticallyIcon />
+      <SpaceEvenlyHorizontallyIcon
+        onClick={() => dispatch('distribute', 'horizontal')}
+      />
+      <SpaceEvenlyVerticallyIcon
+        onClick={() => dispatch('distribute', 'vertical')}
+      />
       <AlignLeftIcon onClick={() => dispatch('align', 'left')} />
       <AlignCenterHorizontallyIcon
-        onClick={() => dispatch('align', 'centerHorizontally')}
+        onClick={() => dispatch('align', 'centerHorizontal')}
       />
       <AlignRightIcon onClick={() => dispatch('align', 'right')} />
       <AlignTopIcon onClick={() => dispatch('align', 'top')} />
       <AlignCenterVerticallyIcon
-        onClick={() => dispatch('align', 'centerVertically')}
+        onClick={() => dispatch('align', 'centerVertical')}
       />
       <AlignBottomIcon onClick={() => dispatch('align', 'bottom')} />
     </AlignmentInspectorContainer>

--- a/packages/app/src/components/inspector/AlignmentInspector.tsx
+++ b/packages/app/src/components/inspector/AlignmentInspector.tsx
@@ -30,10 +30,14 @@ function AlignmentInspector(props: AlignmentInspectorProps) {
       <SpaceEvenlyHorizontallyIcon />
       <SpaceEvenlyVerticallyIcon />
       <AlignLeftIcon onClick={() => dispatch('alignLeft')} />
-      <AlignCenterHorizontallyIcon />
+      <AlignCenterHorizontallyIcon
+        onClick={() => dispatch('alignCenterHorizontally')}
+      />
       <AlignRightIcon onClick={() => dispatch('alignRight')} />
       <AlignTopIcon onClick={() => dispatch('alignTop')} />
-      <AlignCenterVerticallyIcon />
+      <AlignCenterVerticallyIcon
+        onClick={() => dispatch('alignCenterVertically')}
+      />
       <AlignBottomIcon onClick={() => dispatch('alignBottom')} />
     </AlignmentInspectorContainer>
   );

--- a/packages/app/src/components/inspector/AlignmentInspector.tsx
+++ b/packages/app/src/components/inspector/AlignmentInspector.tsx
@@ -29,16 +29,16 @@ function AlignmentInspector(props: AlignmentInspectorProps) {
     <AlignmentInspectorContainer>
       <SpaceEvenlyHorizontallyIcon />
       <SpaceEvenlyVerticallyIcon />
-      <AlignLeftIcon onClick={() => dispatch('alignLeft')} />
+      <AlignLeftIcon onClick={() => dispatch('align', 'left')} />
       <AlignCenterHorizontallyIcon
-        onClick={() => dispatch('alignCenterHorizontally')}
+        onClick={() => dispatch('align', 'centerHorizontally')}
       />
-      <AlignRightIcon onClick={() => dispatch('alignRight')} />
-      <AlignTopIcon onClick={() => dispatch('alignTop')} />
+      <AlignRightIcon onClick={() => dispatch('align', 'right')} />
+      <AlignTopIcon onClick={() => dispatch('align', 'top')} />
       <AlignCenterVerticallyIcon
-        onClick={() => dispatch('alignCenterVertically')}
+        onClick={() => dispatch('align', 'centerVertically')}
       />
-      <AlignBottomIcon onClick={() => dispatch('alignBottom')} />
+      <AlignBottomIcon onClick={() => dispatch('align', 'bottom')} />
     </AlignmentInspectorContainer>
   );
 }

--- a/packages/app/src/containers/AlignmentInspector.tsx
+++ b/packages/app/src/containers/AlignmentInspector.tsx
@@ -10,7 +10,7 @@ import {
   SpaceEvenlyHorizontallyIcon,
   SpaceEvenlyVerticallyIcon,
 } from '@radix-ui/react-icons';
-import { useApplicationState } from '../../contexts/ApplicationStateContext';
+import { useApplicationState } from '../contexts/ApplicationStateContext';
 
 const AlignmentInspectorContainer = styled.div(({ theme }) => ({
   display: 'flex',

--- a/packages/app/src/containers/AlignmentInspector.tsx
+++ b/packages/app/src/containers/AlignmentInspector.tsx
@@ -28,21 +28,21 @@ function AlignmentInspector(props: AlignmentInspectorProps) {
   return (
     <AlignmentInspectorContainer>
       <SpaceEvenlyHorizontallyIcon
-        onClick={() => dispatch('distribute', 'horizontal')}
+        onClick={() => dispatch('distributeLayers', 'horizontal')}
       />
       <SpaceEvenlyVerticallyIcon
-        onClick={() => dispatch('distribute', 'vertical')}
+        onClick={() => dispatch('distributeLayers', 'vertical')}
       />
-      <AlignLeftIcon onClick={() => dispatch('align', 'left')} />
+      <AlignLeftIcon onClick={() => dispatch('alignLayers', 'left')} />
       <AlignCenterHorizontallyIcon
-        onClick={() => dispatch('align', 'centerHorizontal')}
+        onClick={() => dispatch('alignLayers', 'centerHorizontal')}
       />
-      <AlignRightIcon onClick={() => dispatch('align', 'right')} />
-      <AlignTopIcon onClick={() => dispatch('align', 'top')} />
+      <AlignRightIcon onClick={() => dispatch('alignLayers', 'right')} />
+      <AlignTopIcon onClick={() => dispatch('alignLayers', 'top')} />
       <AlignCenterVerticallyIcon
-        onClick={() => dispatch('align', 'centerVertical')}
+        onClick={() => dispatch('alignLayers', 'centerVertical')}
       />
-      <AlignBottomIcon onClick={() => dispatch('align', 'bottom')} />
+      <AlignBottomIcon onClick={() => dispatch('alignLayers', 'bottom')} />
     </AlignmentInspectorContainer>
   );
 }

--- a/packages/app/src/containers/Inspector.tsx
+++ b/packages/app/src/containers/Inspector.tsx
@@ -1,7 +1,7 @@
 import { Divider, Spacer } from 'noya-designsystem';
 import { Selectors } from 'noya-state';
 import { Fragment, memo, useMemo } from 'react';
-import AlignmentInspector from '../components/inspector/AlignmentInspector';
+import AlignmentInspector from './AlignmentInspector';
 import DimensionsInspector, {
   Props as DimensionsInspectorProps,
 } from '../components/inspector/DimensionsInspector';

--- a/packages/noya-state/src/reducers/application.ts
+++ b/packages/noya-state/src/reducers/application.ts
@@ -19,6 +19,7 @@ import {
   getCurrentPageMetadata,
   getSelectedLayerIndexPaths,
   getSelectedLayerIndexPathsExcludingDescendants,
+  getSelectedRect,
 } from '../selectors';
 import { Bounds, Point, UUID } from '../types';
 import { AffineTransform } from '../utils/AffineTransform';
@@ -262,7 +263,7 @@ export function reducer(
       const page = getCurrentPage(state);
       const pageIndex = getCurrentPageIndex(state);
       const layerIndexPaths = getSelectedLayerIndexPaths(state);
-      const selectedRect = getSelectedRect(layerIndexPaths, page);
+      const selectedRect = getSelectedRect(state);
       const [, axis] = action;
 
       return produce(state, (state) => {
@@ -326,7 +327,7 @@ export function reducer(
       const page = getCurrentPage(state);
       const pageIndex = getCurrentPageIndex(state);
       const layerIndexPaths = getSelectedLayerIndexPaths(state);
-      const selectedRect = getSelectedRect(layerIndexPaths, page);
+      const selectedRect = getSelectedRect(state);
       const [, placement] = action;
 
       return produce(state, (state) => {
@@ -985,13 +986,6 @@ function getNormalizedBounds(
   return Primitives.createBounds(
     Primitives.transformRect(layer.frame, transform),
   );
-}
-
-function getSelectedRect(layerIndexPaths: IndexPath[], page: Sketch.Page) {
-  const layerIds = layerIndexPaths.map(
-    (indexPath) => Layers.access(page, indexPath).do_objectID,
-  );
-  return getBoundingRect(page, layerIds)!;
 }
 
 export function createInitialState(sketch: SketchFile): ApplicationState {

--- a/packages/noya-state/src/reducers/application.ts
+++ b/packages/noya-state/src/reducers/application.ts
@@ -77,9 +77,9 @@ export type Action =
   | [type: 'highlightLayer', highlight: LayerHighlight | undefined]
   | [type: 'setExpandedInLayerList', layerId: string, expanded: boolean]
   | [type: 'selectPage', pageId: UUID]
-  | [type: 'distribute', placement: 'horizontal' | 'vertical']
+  | [type: 'distributeLayers', placement: 'horizontal' | 'vertical']
   | [
-      type: 'align',
+      type: 'alignLayers',
       placement:
         | 'left'
         | 'centerHorizontal'
@@ -258,7 +258,7 @@ export function reducer(
         state.selectedPage = action[1];
       });
     }
-    case 'distribute': {
+    case 'distributeLayers': {
       const pageIndex = getCurrentPageIndex(state);
       const layerIndexPaths = getSelectedLayerIndexPaths(state);
       const axis = action[1];
@@ -330,7 +330,7 @@ export function reducer(
         });
       });
     }
-    case 'align': {
+    case 'alignLayers': {
       const pageIndex = getCurrentPageIndex(state);
       const layerIndexPaths = getSelectedLayerIndexPaths(state);
       const placement = action[1];

--- a/packages/noya-state/src/reducers/application.ts
+++ b/packages/noya-state/src/reducers/application.ts
@@ -982,14 +982,9 @@ function getNormalizedBounds(
 ): Bounds {
   const layer = Layers.access(page, layerIndexPath);
   const transform = getNormalizedTransform(page, layerIndexPath);
-  const origin = transform.applyTo({
-    x: layer.frame.x,
-    y: layer.frame.y,
-  });
-  return Primitives.createBounds({
-    ...layer.frame,
-    ...origin,
-  });
+  return Primitives.createBounds(
+    Primitives.transformRect(layer.frame, transform),
+  );
 }
 
 function getSelectedRect(layerIndexPaths: IndexPath[], page: Sketch.Page) {

--- a/packages/noya-state/src/reducers/application.ts
+++ b/packages/noya-state/src/reducers/application.ts
@@ -280,22 +280,11 @@ export function reducer(
         const gapX = differenceWidth / (layers.length - 1);
         const gapY = differenceHeight / (layers.length - 1);
         const sortBy = axis === 'horizontal' ? 'minX' : 'minY'; // TODO: sort by mid point once it's available
-        const sortedLayerIndexPaths = layerIndexPaths
-          .map((layerIndexPath) => {
-            const layer = Layers.access(page, layerIndexPath);
-            const transform = getNormalizedTransform(page, layerIndexPath);
-            const origin = transform.applyTo({
-              x: layer.frame.x,
-              y: layer.frame.y,
-            });
-            const bounds = Primitives.createBounds({
-              ...layer.frame,
-              ...origin,
-            });
-            return [layerIndexPath, bounds] as [IndexPath, Bounds];
-          })
-          .sort((a, b) => a[1][sortBy] - b[1][sortBy])
-          .map(([layerIndexPath]) => layerIndexPath);
+        const sortedLayerIndexPaths = layerIndexPaths.sort(
+          (a, b) =>
+            getNormalizedBounds(page, a)[sortBy] -
+            getNormalizedBounds(page, b)[sortBy],
+        );
 
         let currentX = 0;
         let currentY = 0;
@@ -985,6 +974,22 @@ function getNormalizedTransform(page: Sketch.Page, indexPath: IndexPath) {
         AffineTransform.translation(layer.frame.x, layer.frame.y),
       ),
   );
+}
+
+function getNormalizedBounds(
+  page: Sketch.Page,
+  layerIndexPath: IndexPath,
+): Bounds {
+  const layer = Layers.access(page, layerIndexPath);
+  const transform = getNormalizedTransform(page, layerIndexPath);
+  const origin = transform.applyTo({
+    x: layer.frame.x,
+    y: layer.frame.y,
+  });
+  return Primitives.createBounds({
+    ...layer.frame,
+    ...origin,
+  });
 }
 
 function getSelectedRect(layerIndexPaths: IndexPath[], page: Sketch.Page) {

--- a/packages/noya-state/src/reducers/application.ts
+++ b/packages/noya-state/src/reducers/application.ts
@@ -263,7 +263,7 @@ export function reducer(
       const pageIndex = getCurrentPageIndex(state);
       const layerIndexPaths = getSelectedLayerIndexPaths(state);
       const selectedRect = getSelectedRect(layerIndexPaths, page);
-      const axis = action[1];
+      const [, axis] = action;
 
       return produce(state, (state) => {
         const layers = accessPageLayers(state, pageIndex, layerIndexPaths);
@@ -338,7 +338,7 @@ export function reducer(
       const pageIndex = getCurrentPageIndex(state);
       const layerIndexPaths = getSelectedLayerIndexPaths(state);
       const selectedRect = getSelectedRect(layerIndexPaths, page);
-      const placement = action[1];
+      const [, placement] = action;
 
       return produce(state, (state) => {
         const selectedBounds = createBounds(selectedRect);

--- a/packages/noya-state/src/reducers/application.ts
+++ b/packages/noya-state/src/reducers/application.ts
@@ -259,13 +259,13 @@ export function reducer(
       });
     }
     case 'distributeLayers': {
+      const page = getCurrentPage(state);
       const pageIndex = getCurrentPageIndex(state);
       const layerIndexPaths = getSelectedLayerIndexPaths(state);
+      const selectedRect = getSelectedRect(layerIndexPaths, page);
       const axis = action[1];
 
       return produce(state, (state) => {
-        const page = state.sketch.pages[pageIndex];
-        const selectedRect = getSelectedRect(layerIndexPaths, page);
         const layers = accessPageLayers(state, pageIndex, layerIndexPaths);
         const combinedWidths = layers.reduce(
           (width, layer) => layer.frame.width + width,
@@ -305,7 +305,10 @@ export function reducer(
             page,
             layerIndexPath,
           ).invert();
-          const layer = Layers.access(page, layerIndexPath);
+          const layer = Layers.access(
+            state.sketch.pages[pageIndex], // access page again since we need to write to it
+            layerIndexPath,
+          );
 
           switch (axis) {
             case 'horizontal': {
@@ -331,13 +334,13 @@ export function reducer(
       });
     }
     case 'alignLayers': {
+      const page = getCurrentPage(state);
       const pageIndex = getCurrentPageIndex(state);
       const layerIndexPaths = getSelectedLayerIndexPaths(state);
+      const selectedRect = getSelectedRect(layerIndexPaths, page);
       const placement = action[1];
 
       return produce(state, (state) => {
-        const page = state.sketch.pages[pageIndex];
-        const selectedRect = getSelectedRect(layerIndexPaths, page);
         const selectedBounds = createBounds(selectedRect);
         const midX = selectedRect.x + selectedRect.width / 2;
         const midY = selectedRect.y + selectedRect.height / 2;
@@ -347,7 +350,10 @@ export function reducer(
             page,
             layerIndexPath,
           ).invert();
-          const layer = Layers.access(page, layerIndexPath);
+          const layer = Layers.access(
+            state.sketch.pages[pageIndex], // access page again since we need to write to it
+            layerIndexPath,
+          );
 
           switch (placement) {
             case 'left': {

--- a/packages/noya-state/src/reducers/application.ts
+++ b/packages/noya-state/src/reducers/application.ts
@@ -270,10 +270,16 @@ export function reducer(
       return produce(state, (state) => {
         const layers = accessPageLayers(state, pageIndex, layerIndexPaths);
         const [rightmostLayer] = layers.sort(
-          (layerA, layerB) => layerB.frame.x - layerA.frame.x,
+          (layerA, layerB) =>
+            layerB.frame.x +
+            layerB.frame.width -
+            (layerA.frame.x + layerA.frame.width),
         );
         layers.forEach((layer) => {
-          layer.frame.x = rightmostLayer.frame.x;
+          layer.frame.x =
+            rightmostLayer.frame.x +
+            rightmostLayer.frame.width -
+            layer.frame.width;
         });
       });
     }
@@ -298,10 +304,16 @@ export function reducer(
       return produce(state, (state) => {
         const layers = accessPageLayers(state, pageIndex, layerIndexPaths);
         const [bottommostLayer] = layers.sort(
-          (layerA, layerB) => layerB.frame.y - layerA.frame.y,
+          (layerA, layerB) =>
+            layerB.frame.y +
+            layerB.frame.height -
+            (layerA.frame.y + layerA.frame.height),
         );
         layers.forEach((layer) => {
-          layer.frame.y = bottommostLayer.frame.y;
+          layer.frame.y =
+            bottommostLayer.frame.y +
+            bottommostLayer.frame.height -
+            layer.frame.height;
         });
       });
     }

--- a/packages/noya-state/src/reducers/application.ts
+++ b/packages/noya-state/src/reducers/application.ts
@@ -291,7 +291,7 @@ export function reducer(
         let currentY = 0;
 
         sortedLayerIndexPaths.forEach((layerIndexPath) => {
-          const normalizedTransform = getNormalizedTransform(
+          const transform = getLayerTransformAtIndexPath(
             page,
             layerIndexPath,
           ).invert();
@@ -302,7 +302,7 @@ export function reducer(
 
           switch (axis) {
             case 'horizontal': {
-              const newOrigin = normalizedTransform.applyTo({
+              const newOrigin = transform.applyTo({
                 x: selectedRect.x + currentX,
                 y: 0,
               });
@@ -311,7 +311,7 @@ export function reducer(
               break;
             }
             case 'vertical': {
-              const newOrigin = normalizedTransform.applyTo({
+              const newOrigin = transform.applyTo({
                 x: 0,
                 y: selectedRect.y + currentY,
               });
@@ -336,7 +336,7 @@ export function reducer(
         const midY = selectedRect.y + selectedRect.height / 2;
 
         layerIndexPaths.forEach((layerIndexPath) => {
-          const normalizedTransform = getNormalizedTransform(
+          const transform = getLayerTransformAtIndexPath(
             page,
             layerIndexPath,
           ).invert();
@@ -347,7 +347,7 @@ export function reducer(
 
           switch (placement) {
             case 'left': {
-              const newOrigin = normalizedTransform.applyTo({
+              const newOrigin = transform.applyTo({
                 x: selectedBounds.minX,
                 y: 0,
               });
@@ -355,7 +355,7 @@ export function reducer(
               break;
             }
             case 'centerHorizontal': {
-              const newOrigin = normalizedTransform.applyTo({
+              const newOrigin = transform.applyTo({
                 x: midX - layer.frame.width / 2,
                 y: 0,
               });
@@ -363,7 +363,7 @@ export function reducer(
               break;
             }
             case 'right': {
-              const newOrigin = normalizedTransform.applyTo({
+              const newOrigin = transform.applyTo({
                 x: selectedBounds.maxX - layer.frame.width,
                 y: 0,
               });
@@ -371,7 +371,7 @@ export function reducer(
               break;
             }
             case 'top': {
-              const newOrigin = normalizedTransform.applyTo({
+              const newOrigin = transform.applyTo({
                 x: 0,
                 y: selectedBounds.minY,
               });
@@ -379,7 +379,7 @@ export function reducer(
               break;
             }
             case 'centerVertical': {
-              const newOrigin = normalizedTransform.applyTo({
+              const newOrigin = transform.applyTo({
                 x: 0,
                 y: midY - layer.frame.height / 2,
               });
@@ -387,7 +387,7 @@ export function reducer(
               break;
             }
             case 'bottom': {
-              const newOrigin = normalizedTransform.applyTo({
+              const newOrigin = transform.applyTo({
                 x: 0,
                 y: selectedBounds.maxY - layer.frame.height,
               });
@@ -967,9 +967,12 @@ function accessPageLayers(
   });
 }
 
-function getNormalizedTransform(page: Sketch.Page, indexPath: IndexPath) {
+function getLayerTransformAtIndexPath(
+  node: Sketch.AnyLayer,
+  indexPath: IndexPath,
+) {
   return AffineTransform.multiply(
-    ...Layers.accessPath(page, indexPath)
+    ...Layers.accessPath(node, indexPath)
       .slice(1, -1) // Remove the page and current layer
       .map((layer) =>
         AffineTransform.translation(layer.frame.x, layer.frame.y),
@@ -982,7 +985,7 @@ function getNormalizedBounds(
   layerIndexPath: IndexPath,
 ): Bounds {
   const layer = Layers.access(page, layerIndexPath);
-  const transform = getNormalizedTransform(page, layerIndexPath);
+  const transform = getLayerTransformAtIndexPath(page, layerIndexPath);
   return Primitives.createBounds(
     Primitives.transformRect(layer.frame, transform),
   );

--- a/packages/noya-state/src/selectors.ts
+++ b/packages/noya-state/src/selectors.ts
@@ -103,6 +103,15 @@ export const getSelectedLayers = (state: ApplicationState): PageLayer[] => {
   ) as PageLayer[];
 };
 
+export const getSelectedRect = (state: ApplicationState): Rect => {
+  const page = getCurrentPage(state);
+  const layerIndexPaths = getSelectedLayerIndexPaths(state);
+  const layerIds = layerIndexPaths.map(
+    (indexPath) => Layers.access(page, indexPath).do_objectID,
+  );
+  return getBoundingRect(page, layerIds)!;
+};
+
 export const getSelectedLayersWithContextSettings = (
   state: ApplicationState,
 ): PageLayer[] => {


### PR DESCRIPTION
Finishes alignment inspector by consolidating `align` into one action as well as adding a `distribute` action. This now utilizes `AffineTransform` to properly space nested layers. We'll need to account for some weird cases as ExcaliDraw does [here](https://github.com/excalidraw/excalidraw/blob/master/src/disitrubte.ts) and make sure to disable buttons when an alignment/distribution cannot be made (e.g. you can't distribute less than 3 layers).

![align](https://user-images.githubusercontent.com/2762082/111199577-06b79480-857e-11eb-8784-ddd279e4c6fd.gif)
