### PR TITLE
Correction: Show the theme inspector in the layers inspectors

### DIFF
--- a/packages/app/src/containers/Inspector.tsx
+++ b/packages/app/src/containers/Inspector.tsx
@@ -13,7 +13,7 @@ import AlignmentInspector from './AlignmentInspector';
 import ArtboardSizeList from './ArtboardSizeList';
 import BorderInspector from './BorderInspector';
 import FillInspector from './FillInspector';
-import LayerThemeInspector from './ThemeStyleInspector';
+import LayerThemeInspector from './LayerThemeInspector';
 import OpacityInspector from './OpacityInspector';
 import RadiusInspector from './RadiusInspector';
 import ShadowInspector from './ShadowInspector';


### PR DESCRIPTION
I changed the files names and it wasn't showing the inspector in the layers inspectors


Before: 
![image](https://user-images.githubusercontent.com/16924758/115626710-7a5a6900-a2c3-11eb-87fb-29d5a2691e37.png)

Now:
![image](https://user-images.githubusercontent.com/16924758/115626594-59921380-a2c3-11eb-9778-9deb178db89d.png)
