### PR TITLE
Move workspace state above history state

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,15 +1,15 @@
+import { parse, SketchFile } from 'noya-sketch-file';
 import {
-  createInitialHistoryState,
-  HistoryAction,
-  historyReducer,
-  HistoryState,
+  createInitialWorkspaceState,
+  WorkspaceAction,
+  workspaceReducer,
+  WorkspaceState,
 } from 'noya-state';
 import { useCallback, useEffect, useMemo, useReducer } from 'react';
-import { parse, SketchFile } from 'noya-sketch-file';
 import Workspace from './containers/Workspace';
 import {
-  ApplicationStateProvider,
   ApplicationStateContextValue,
+  ApplicationStateProvider,
 } from './contexts/ApplicationStateContext';
 import { useResource } from './hooks/useResource';
 import { PromiseState } from './utils/PromiseState';
@@ -19,22 +19,22 @@ export default function App() {
 
   const [state, dispatch] = useReducer(
     (
-      state: PromiseState<HistoryState>,
+      state: PromiseState<WorkspaceState>,
       action:
         | { type: 'set'; value: SketchFile }
-        | { type: 'update'; value: HistoryAction },
-    ): PromiseState<HistoryState> => {
+        | { type: 'update'; value: WorkspaceAction },
+    ): PromiseState<WorkspaceState> => {
       switch (action.type) {
         case 'set':
           return {
             type: 'success',
-            value: createInitialHistoryState(action.value),
+            value: createInitialWorkspaceState(action.value),
           };
         case 'update':
           if (state.type === 'success') {
             return {
               type: 'success',
-              value: historyReducer(state.value, action.value),
+              value: workspaceReducer(state.value, action.value),
             };
           } else {
             return state;
@@ -50,7 +50,7 @@ export default function App() {
     });
   }, [sketchFile]);
 
-  const handleDispatch = useCallback((action: HistoryAction) => {
+  const handleDispatch = useCallback((action: WorkspaceAction) => {
     dispatch({ type: 'update', value: action });
   }, []);
 

--- a/packages/app/src/containers/LayerList.tsx
+++ b/packages/app/src/containers/LayerList.tsx
@@ -24,6 +24,7 @@ import { visit } from 'tree-visit';
 import {
   useApplicationState,
   useSelector,
+  useWorkspace,
 } from '../contexts/ApplicationStateContext';
 import useDeepArray from '../hooks/useDeepArray';
 import useShallowArray from '../hooks/useShallowArray';
@@ -172,6 +173,7 @@ const LayerRow = memo(
 export default memo(function LayerList() {
   const [state, dispatch] = useApplicationState();
   const page = useSelector(Selectors.getCurrentPage);
+  const { highlightLayer } = useWorkspace();
   const selectedObjects = useShallowArray(state.selectedObjects);
   const items = useDeepArray(flattenLayerList(page, selectedObjects));
 
@@ -231,8 +233,7 @@ export default memo(function LayerList() {
         };
 
         const handleHoverChange = (hovered: boolean) => {
-          dispatch(
-            'highlightLayer',
+          highlightLayer(
             hovered ? { id, precedence: 'aboveSelection' } : undefined,
           );
         };
@@ -272,7 +273,14 @@ export default memo(function LayerList() {
         );
       },
     );
-  }, [items, menuItems, dispatch, selectedObjects, onSelectMenuItem]);
+  }, [
+    items,
+    menuItems,
+    onSelectMenuItem,
+    dispatch,
+    selectedObjects,
+    highlightLayer,
+  ]);
 
   return (
     <TreeView.Root

--- a/packages/app/src/containers/Toolbar.tsx
+++ b/packages/app/src/containers/Toolbar.tsx
@@ -13,6 +13,7 @@ import styled, { useTheme } from 'styled-components';
 import {
   useApplicationState,
   useHistory,
+  useWorkspace,
 } from '../contexts/ApplicationStateContext';
 
 const Container = styled.header(({ theme }) => ({
@@ -26,9 +27,12 @@ const Container = styled.header(({ theme }) => ({
 
 export default function Toolbar() {
   const [state, dispatch] = useApplicationState();
+  const {
+    setShowRulers,
+    preferences: { showRulers },
+  } = useWorkspace();
   const { redo, redoDisabled, undo, undoDisabled } = useHistory();
-  const { interactionState, preferences } = state;
-  const showRulers = preferences.showRulers;
+  const { interactionState } = state;
   const itemSeparatorSize = useTheme().sizes.toolbar.itemSeparator;
   const interactionType = interactionState.type;
 
@@ -120,7 +124,7 @@ export default function Toolbar() {
           tooltip="Show rulers"
           active={showRulers}
           onClick={() => {
-            dispatch('setShowRulers', !showRulers);
+            setShowRulers(!showRulers);
           }}
         >
           <RulerHorizontalIcon />
@@ -140,6 +144,7 @@ export default function Toolbar() {
       itemSeparatorSize,
       redo,
       redoDisabled,
+      setShowRulers,
       showRulers,
       undo,
       undoDisabled,

--- a/packages/noya-renderer/src/components/Rulers.tsx
+++ b/packages/noya-renderer/src/components/Rulers.tsx
@@ -1,4 +1,7 @@
-import { useApplicationState } from 'app/src/contexts/ApplicationStateContext';
+import {
+  useApplicationState,
+  useWorkspace,
+} from 'app/src/contexts/ApplicationStateContext';
 import {
   Rect as RCKRect,
   Text,
@@ -78,8 +81,8 @@ export function HorizontalRuler() {
   const backgroundColor = useTheme().colors.canvas.background;
 
   const [state] = useApplicationState();
+  const { canvasSize } = useWorkspace();
   const page = getCurrentPage(state);
-  const canvasSize = state.canvasSize;
   const { scrollOrigin } = getCurrentPageMetadata(state);
 
   const rulerRect = useMemo(

--- a/packages/noya-renderer/src/components/SketchFileRenderer.tsx
+++ b/packages/noya-renderer/src/components/SketchFileRenderer.tsx
@@ -1,4 +1,7 @@
-import { useApplicationState } from 'app/src/contexts/ApplicationStateContext';
+import {
+  useApplicationState,
+  useWorkspace,
+} from 'app/src/contexts/ApplicationStateContext';
 import * as CanvasKit from 'canvaskit-wasm';
 import { AffineTransform, createRect, insetRect } from 'noya-geometry';
 import {
@@ -109,15 +112,18 @@ const Marquee = memo(function Marquee({
 });
 
 export default memo(function SketchFileRenderer() {
+  const {
+    canvasSize,
+    canvasInsets,
+    preferences: { showRulers },
+    highlightedLayer,
+  } = useWorkspace();
   const [state] = useApplicationState();
   const { CanvasKit } = useReactCanvasKit();
   const page = getCurrentPage(state);
-  const showRulers = state.preferences.showRulers;
-  const screenTransform = getScreenTransform(state);
-  const canvasTransform = getCanvasTransform(state);
+  const screenTransform = getScreenTransform(canvasInsets);
+  const canvasTransform = getCanvasTransform(state, canvasInsets);
 
-  const canvasSize = state.canvasSize;
-  const canvasInsets = state.canvasInsets;
   const canvasRect = useMemo(
     () =>
       CanvasKit.XYWHRect(
@@ -163,9 +169,7 @@ export default memo(function SketchFileRenderer() {
     [page, state.selectedObjects],
   );
 
-  const highlightedLayer = useMemo(() => {
-    const highlightedLayer = state.highlightedLayer;
-
+  const highlightedSketchLayer = useMemo(() => {
     if (
       !highlightedLayer ||
       // Don't draw a highlight when hovering over a selected layer on the canvas
@@ -198,7 +202,7 @@ export default memo(function SketchFileRenderer() {
         />
       )
     );
-  }, [highlightPaint, page, state.highlightedLayer, state.selectedObjects]);
+  }, [highlightPaint, highlightedLayer, page, state.selectedObjects]);
 
   return (
     <>
@@ -213,7 +217,7 @@ export default memo(function SketchFileRenderer() {
         {boundingPoints.map((points, index) => (
           <Polyline key={index} points={points} paint={selectionPaint} />
         ))}
-        {highlightedLayer}
+        {highlightedSketchLayer}
         {boundingRect && (
           <DragHandles rect={boundingRect} selectionPaint={selectionPaint} />
         )}

--- a/packages/noya-state/src/index.ts
+++ b/packages/noya-state/src/index.ts
@@ -2,6 +2,7 @@ export * as Layers from './layers';
 export * as Selectors from './selectors';
 export * as Models from './models';
 
+export * from './reducers/workspace';
 export * from './reducers/application';
 export * from './reducers/history';
 export * from './reducers/interaction';

--- a/packages/noya-state/src/reducers/application.ts
+++ b/packages/noya-state/src/reducers/application.ts
@@ -42,18 +42,10 @@ export type WorkspaceTab = 'canvas' | 'theme';
 
 export type ThemeTab = 'swatches' | 'textStyles' | 'layerStyles' | 'symbols';
 
-export type LayerHighlightPrecedence = 'aboveSelection' | 'belowSelection';
-
-export type LayerHighlight = {
-  id: string;
-  precedence: LayerHighlightPrecedence;
-};
-
 export type ApplicationState = {
   currentTab: WorkspaceTab;
   currentThemeTab: ThemeTab;
   interactionState: InteractionState;
-  highlightedLayer?: LayerHighlight;
   selectedPage: string;
   selectedObjects: string[];
   selectedSwatchIds: string[];
@@ -61,11 +53,6 @@ export type ApplicationState = {
   selectedSwatchGroup: string;
   selectedThemeStyleGroup: string;
   sketch: SketchFile;
-  canvasSize: { width: number; height: number };
-  canvasInsets: { left: number; right: number };
-  preferences: {
-    showRulers: boolean;
-  };
 };
 
 export type SelectionType = 'replace' | 'intersection' | 'difference';
@@ -73,12 +60,6 @@ export type SelectionType = 'replace' | 'intersection' | 'difference';
 export type Action =
   | [type: 'setTab', value: WorkspaceTab]
   | [type: 'setThemeTab', value: ThemeTab]
-  | [
-      type: 'setCanvasSize',
-      size: { width: number; height: number },
-      insets: { left: number; right: number },
-    ]
-  | [type: 'setShowRulers', value: boolean]
   | [type: 'movePage', sourceIndex: number, destinationIndex: number]
   | [
       type: 'insertArtboard',
@@ -101,7 +82,6 @@ export type Action =
       sharedStyleId: string | string[] | undefined,
       selectionType?: SelectionType,
     ]
-  | [type: 'highlightLayer', highlight: LayerHighlight | undefined]
   | [type: 'setLayerVisible', layerId: string | string[], visible: boolean]
   | [type: 'setExpandedInLayerList', layerId: string, expanded: boolean]
   | [type: 'selectPage', pageId: UUID]
@@ -191,21 +171,6 @@ export function reducer(
 
       return produce(state, (draft) => {
         draft.currentThemeTab = value;
-      });
-    }
-    case 'setCanvasSize': {
-      const [, size, insets] = action;
-
-      return produce(state, (draft) => {
-        draft.canvasSize = size;
-        draft.canvasInsets = insets;
-      });
-    }
-    case 'setShowRulers': {
-      const [, value] = action;
-
-      return produce(state, (draft) => {
-        draft.preferences.showRulers = value;
       });
     }
     case 'insertArtboard': {
@@ -341,13 +306,6 @@ export function reducer(
             draft.selectedObjects = [...ids];
             return;
         }
-      });
-    }
-    case 'highlightLayer': {
-      const [, highlight] = action;
-
-      return produce(state, (draft) => {
-        draft.highlightedLayer = highlight ? { ...highlight } : undefined;
       });
     }
     case 'selectPage': {
@@ -1293,12 +1251,6 @@ export function createInitialState(sketch: SketchFile): ApplicationState {
     selectedLayerStyleIds: [],
     selectedSwatchGroup: '',
     selectedThemeStyleGroup: '',
-    highlightedLayer: undefined,
     sketch,
-    canvasSize: { width: 0, height: 0 },
-    canvasInsets: { left: 0, right: 0 },
-    preferences: {
-      showRulers: false,
-    },
   };
 }

--- a/packages/noya-state/src/reducers/workspace.ts
+++ b/packages/noya-state/src/reducers/workspace.ts
@@ -1,0 +1,100 @@
+import produce from 'immer';
+import { SketchFile } from 'noya-sketch-file';
+import {
+  createInitialHistoryState,
+  HistoryAction,
+  historyReducer,
+  HistoryState,
+} from './history';
+
+export type LayerHighlightPrecedence = 'aboveSelection' | 'belowSelection';
+
+export type LayerHighlight = {
+  id: string;
+  precedence: LayerHighlightPrecedence;
+};
+
+export type CanvasInsets = { left: number; right: number };
+
+/**
+ * This object contains state that shouldn't be part of `history`.
+ * For example, we store user `preferences` here, since we would never
+ * want an "undo" action to change the user's preferences.
+ */
+export type WorkspaceState = {
+  history: HistoryState;
+  highlightedLayer?: LayerHighlight;
+  canvasSize: { width: number; height: number };
+  canvasInsets: CanvasInsets;
+  preferences: {
+    showRulers: boolean;
+  };
+};
+
+export type WorkspaceAction =
+  | [
+      type: 'setCanvasSize',
+      size: { width: number; height: number },
+      insets: { left: number; right: number },
+    ]
+  | [type: 'setShowRulers', value: boolean]
+  | [type: 'highlightLayer', highlight: LayerHighlight | undefined]
+  | HistoryAction;
+
+export function workspaceReducer(
+  state: WorkspaceState,
+  action: WorkspaceAction,
+): WorkspaceState {
+  switch (action[0]) {
+    case 'setCanvasSize': {
+      const [, size, insets] = action;
+
+      if (
+        size.width === state.canvasSize.width &&
+        size.height === state.canvasSize.height &&
+        insets.left === state.canvasInsets.left &&
+        insets.right === state.canvasInsets.right
+      ) {
+        return state;
+      }
+
+      return produce(state, (draft) => {
+        draft.canvasSize = size;
+        draft.canvasInsets = insets;
+      });
+    }
+    case 'setShowRulers': {
+      const [, value] = action;
+
+      return produce(state, (draft) => {
+        draft.preferences.showRulers = value;
+      });
+    }
+    case 'highlightLayer': {
+      const [, highlight] = action;
+
+      return produce(state, (draft) => {
+        draft.highlightedLayer = highlight ? { ...highlight } : undefined;
+      });
+    }
+    default: {
+      return produce(state, (draft) => {
+        draft.history = historyReducer(state.history, action);
+      });
+    }
+  }
+}
+
+export function createInitialWorkspaceState(
+  sketch: SketchFile,
+): WorkspaceState {
+  return {
+    history: createInitialHistoryState(sketch),
+    highlightedLayer: undefined,
+    canvasSize: { width: 0, height: 0 },
+    canvasInsets: { left: 0, right: 0 },
+    preferences: {
+      showRulers: false,
+    },
+  };
+}


### PR DESCRIPTION
This creates a new reducer for managing non-undoable UI state. 

There are possibly a few other properties that should go in here, like `currentTab`, but that will require changes to a few things in the `application` reducer, so it can happen another time.