### PR TITLE
Improve string attribute handling

### DIFF
--- a/packages/app/src/components/inspector/TextOptionsRow.tsx
+++ b/packages/app/src/components/inspector/TextOptionsRow.tsx
@@ -1,71 +1,55 @@
-import Sketch from '@sketch-hq/sketch-file-format-ts';
 import {
-  LetterCaseLowercaseIcon,
   LetterCaseCapitalizeIcon,
+  LetterCaseLowercaseIcon,
   LetterCaseUppercaseIcon,
 } from '@radix-ui/react-icons';
+import Sketch from '@sketch-hq/sketch-file-format-ts';
 import {
   Label,
-  Select,
-  RadioGroup,
   LabeledElementView,
+  RadioGroup,
+  Select,
+  Spacer,
 } from 'noya-designsystem';
-import { Spacer } from 'noya-designsystem';
-import { useCallback, useMemo, memo } from 'react';
+import { SimpleTextDecoration } from 'noya-renderer';
+import { memo, useCallback } from 'react';
 import * as InspectorPrimitives from './InspectorPrimitives';
 
-export type SimpleTextDecoration = 'none' | 'underline' | 'strikethrough';
-
 interface TextOptionsRowProps {
-  textCase?: Sketch.TextTransform;
-  textDecorator?: SimpleTextDecoration;
-  onChangeTextCase: (value: Sketch.TextTransform) => void;
-  onChangeTextDecorator: (value: number) => void;
+  textTransform?: Sketch.TextTransform;
+  textDecoration?: SimpleTextDecoration;
+  onChangeTextTransform: (value: Sketch.TextTransform) => void;
+  onChangeTextDecoration: (value: SimpleTextDecoration) => void;
 }
 
+const capitalize = (value: string) =>
+  value.charAt(0).toUpperCase() + value.slice(1);
+
+const TextDecorationOptions: SimpleTextDecoration[] = [
+  'none',
+  'underline',
+  'strikethrough',
+];
+
+const decorationInputId = `decoration`;
+const transformInputId = `transform`;
+
 export default memo(function TextOptionsRow({
-  textCase,
-  textDecorator,
-  onChangeTextCase,
-  onChangeTextDecorator,
+  textTransform,
+  textDecoration,
+  onChangeTextTransform,
+  onChangeTextDecoration,
 }: TextOptionsRowProps) {
-  const decoratorInputId = `decorator`;
-  const transformInputId = `transform`;
-
-  const decorator = useMemo(
-    () => [
-      { id: 0, name: 'None' },
-      { id: 1, name: 'Underline' },
-      { id: 2, name: 'Strikethrough' },
-    ],
-    [],
-  );
-
-  const renderLabel = useCallback(
-    ({ id }) => {
-      switch (id) {
-        case decoratorInputId:
-          return <Label.Label>Decoration</Label.Label>;
-        case transformInputId:
-          return <Label.Label>Transform</Label.Label>;
-        default:
-          return null;
-      }
-    },
-    [decoratorInputId, transformInputId],
-  );
-
-  const onChangeDecorator = useCallback(
-    (value) => {
-      const id = decorator.find((d) => d.name === value)?.id || 0;
-      onChangeTextDecorator(id);
-    },
-    [onChangeTextDecorator, decorator],
-  );
-
-  const textDecoratorCapitalize = textDecorator
-    ? textDecorator.charAt(0).toUpperCase() + textDecorator.slice(1)
-    : '';
+  const renderLabel = useCallback(({ id }) => {
+    switch (id) {
+      case decorationInputId:
+        return <Label.Label>Decoration</Label.Label>;
+      case transformInputId:
+        return <Label.Label>Transform</Label.Label>;
+      default:
+        return null;
+    }
+  }, []);
 
   return (
     <InspectorPrimitives.Section>
@@ -75,20 +59,21 @@ export default memo(function TextOptionsRow({
       <Spacer.Vertical size={10} />
       <InspectorPrimitives.Row>
         <LabeledElementView renderLabel={renderLabel}>
-          <Select
-            id={decoratorInputId}
-            value={textDecoratorCapitalize}
-            options={decorator.map((d) => d.name)}
-            getTitle={(name) => name}
-            onChange={onChangeDecorator}
+          <Select<SimpleTextDecoration>
+            id={decorationInputId}
+            value={textDecoration ?? 'none'}
+            options={TextDecorationOptions}
+            getTitle={capitalize}
+            onChange={onChangeTextDecoration}
           />
           <Spacer.Horizontal size={8} />
           <RadioGroup.Root
             id={transformInputId}
-            value={textCase !== undefined ? textCase.toString() : ''}
-            onValueChange={(event) =>
-              onChangeTextCase(parseInt(event.target.value))
-            }
+            value={textTransform !== undefined ? textTransform.toString() : ''}
+            onValueChange={useCallback(
+              (event) => onChangeTextTransform(parseInt(event.target.value)),
+              [onChangeTextTransform],
+            )}
           >
             <RadioGroup.Item
               value={Sketch.TextTransform.None.toString()}

--- a/packages/app/src/containers/TextStyleInspector.tsx
+++ b/packages/app/src/containers/TextStyleInspector.tsx
@@ -1,17 +1,15 @@
 import Sketch from '@sketch-hq/sketch-file-format-ts';
 import { Divider } from 'noya-designsystem';
 import { Selectors } from 'noya-state';
-import { useCallback, memo, useMemo } from 'react';
-import useShallowArray from '../hooks/useShallowArray';
-import TextOptionsRow, {
-  SimpleTextDecoration,
-} from '../components/inspector/TextOptionsRow';
+import { memo, useCallback, useMemo } from 'react';
 import TextAlignmentRow from '../components/inspector/TextLayoutRow';
+import TextOptionsRow from '../components/inspector/TextOptionsRow';
 import TextStyleRow from '../components/inspector/TextStyleRow';
 import {
-  useSelector,
   useApplicationState,
+  useSelector,
 } from '../contexts/ApplicationStateContext';
+import useShallowArray from '../hooks/useShallowArray';
 import getMultiValue from '../utils/getMultiValue';
 
 export default memo(function TextStyleInspector() {
@@ -29,13 +27,13 @@ export default memo(function TextStyleInspector() {
 
     const attributes = layer.attributedString.attributes;
 
-    const color = {
+    const color: Sketch.Color = {
       _class: 'color',
       red: 0.5,
       blue: 0.5,
       green: 0.5,
       alpha: 0.5,
-    } as Sketch.Color;
+    };
 
     return {
       fontColor: encodedAttributes?.MSAttributedStringColorAttribute || color,
@@ -93,10 +91,10 @@ export default memo(function TextStyleInspector() {
           Sketch.TextTransform.None
         : undefined,
       textDecoration: encodedAttributes?.underlineStyle
-        ? 'underline'
+        ? ('underline' as const)
         : encodedAttributes?.strikethroughStyle
-        ? 'strikethrough'
-        : 'none',
+        ? ('strikethrough' as const)
+        : ('none' as const),
       letterSpacing:
         getMultiValue<number | undefined>(
           layers.map((l) => l.style?.textStyle?.encodedAttributes?.kerning),
@@ -218,14 +216,14 @@ export default memo(function TextStyleInspector() {
       />
       <Divider />
       <TextOptionsRow
-        textCase={textTransform}
-        textDecorator={textDecoration as SimpleTextDecoration}
-        onChangeTextDecorator={useCallback(
+        textTransform={textTransform}
+        textDecoration={textDecoration}
+        onChangeTextDecoration={useCallback(
           (value) => dispatch('setTextDecoration', value),
           [dispatch],
         )}
-        onChangeTextCase={useCallback(
-          (value: Sketch.TextTransform) => dispatch('setTextCase', value),
+        onChangeTextTransform={useCallback(
+          (value) => dispatch('setTextTransform', value),
           [dispatch],
         )}
       />

--- a/packages/noya-renderer/src/components/layers/SketchText.tsx
+++ b/packages/noya-renderer/src/components/layers/SketchText.tsx
@@ -29,7 +29,7 @@ function getTextStyleAttributes(layer: Sketch.Text) {
       ? ('underline' as const)
       : encodedAttributes?.strikethroughStyle
       ? ('strikethrough' as const)
-      : undefined,
+      : ('none' as const),
   };
 }
 

--- a/packages/noya-renderer/src/index.ts
+++ b/packages/noya-renderer/src/index.ts
@@ -6,6 +6,7 @@ export { default as SketchFileRenderer } from './components/SketchFileRenderer';
 
 export type { Context };
 export { uuid, Primitives };
+export type SimpleTextDecoration = Primitives.SimpleTextDecoration;
 
 export let fontManager: FontMgr;
 

--- a/packages/noya-renderer/src/primitives.ts
+++ b/packages/noya-renderer/src/primitives.ts
@@ -226,12 +226,12 @@ export function textHorizontalAlignment(
   }
 }
 
-export type SimpleTextDecoration = 'underline' | 'strikethrough';
+export type SimpleTextDecoration = 'none' | 'underline' | 'strikethrough';
 
 export function stringAttribute(
   CanvasKit: CanvasKit,
   attribute: Sketch.StringAttribute,
-  decoration?: SimpleTextDecoration,
+  decoration: SimpleTextDecoration,
 ): TextStyle {
   const textColor = attribute.attributes.MSAttributedStringColorAttribute;
   const font = attribute.attributes.MSAttributedStringFontAttribute;
@@ -241,13 +241,15 @@ export function stringAttribute(
     // fontFamilies: ['Roboto'], // TODO: Font family
     fontSize: font.attributes.size,
     letterSpacing: attribute.attributes.kerning,
-    ...(decoration && {
-      decoration:
-        decoration === 'underline'
-          ? CanvasKit.UnderlineDecoration
-          : CanvasKit.LineThroughDecoration,
-      // There's currently a typo in the TypeScript types, "decration"
-      ['decorationStyle' as any]: CanvasKit.DecorationStyle.Solid,
-    }),
+    ...(decoration === 'none'
+      ? {}
+      : {
+          decoration:
+            decoration === 'underline'
+              ? CanvasKit.UnderlineDecoration
+              : CanvasKit.LineThroughDecoration,
+          // There's currently a typo in the TypeScript types, "decration"
+          ['decorationStyle' as any]: CanvasKit.DecorationStyle.Solid,
+        }),
   });
 }

--- a/packages/noya-state/src/reducers/stringAttribute.ts
+++ b/packages/noya-state/src/reducers/stringAttribute.ts
@@ -1,50 +1,39 @@
 import Sketch from '@sketch-hq/sketch-file-format-ts';
 import produce from 'immer';
 
-export type TextStyleAction =
+export type StringAttributeAction =
   | [type: 'setTextColor', value: Sketch.Color]
   | [type: 'setTextFontName', value: string]
   | [type: 'setTextFontSize', value: number]
   | [type: 'setTextLetterSpacing', value: number]
   | [type: 'setTextLineSpacing', value: number]
   | [type: 'setTextParagraphSpacing', value: number]
-  | [type: 'setTextAlignment', value: number]
   | [type: 'setTextHorizontalAlignment', value: number]
-  | [type: 'setTextVerticalAlignment', value: number]
-  | [type: 'setTextDecoration', value: number]
-  | [type: 'setTextCase', value: number];
+  | [type: 'setTextVerticalAlignment', value: number];
 
-export function stringAttributeReducer(
-  state: Sketch.TextStyle | Sketch.StringAttribute,
-  action: TextStyleAction,
-): Sketch.TextStyle | Sketch.StringAttribute {
+type CommonStringAttributes =
+  | Sketch.StringAttribute['attributes']
+  | Sketch.TextStyle['encodedAttributes'];
+
+export function stringAttributeReducer<T extends CommonStringAttributes>(
+  state: T,
+  action: StringAttributeAction,
+): T {
   switch (action[0]) {
     case 'setTextColor': {
       const [, color] = action;
 
       return produce(state, (draft) => {
-        const attributes =
-          draft._class === 'stringAttribute'
-            ? draft.attributes
-            : draft.encodedAttributes;
-
-        if (!attributes) return;
-
-        attributes.MSAttributedStringColorAttribute = color;
+        draft.MSAttributedStringColorAttribute = color;
       });
     }
     case 'setTextFontName': {
       const [, value] = action;
 
       return produce(state, (draft) => {
-        const attributes =
-          draft._class === 'stringAttribute'
-            ? draft.attributes.MSAttributedStringFontAttribute.attributes
-            : draft.encodedAttributes.MSAttributedStringFontAttribute
-                .attributes;
+        const attributes = draft.MSAttributedStringFontAttribute.attributes;
 
-        if (!attributes) return;
-
+        // This logic is temporary and will be replaced when we handle fonts
         const split = attributes.name.split('-');
         const face = split[1] ? '-' + split[1] : '';
 
@@ -57,113 +46,58 @@ export function stringAttributeReducer(
       const [, value] = action;
 
       return produce(state, (draft) => {
-        const attributes =
-          draft._class === 'stringAttribute'
-            ? draft.attributes.MSAttributedStringFontAttribute.attributes
-            : draft.encodedAttributes.MSAttributedStringFontAttribute
-                .attributes;
-
-        if (!attributes) return;
-
-        attributes.size = value;
+        draft.MSAttributedStringFontAttribute.attributes.size = value;
       });
     }
     case 'setTextLetterSpacing': {
       const [, value] = action;
 
       return produce(state, (draft) => {
-        const attributes =
-          draft._class === 'stringAttribute'
-            ? draft.attributes
-            : draft.encodedAttributes;
-
-        if (!attributes) return;
-
-        attributes.kerning = value;
+        draft.kerning = value;
       });
     }
     case 'setTextLineSpacing': {
       const [, value] = action;
 
       return produce(state, (draft) => {
-        const attributes =
-          draft._class === 'stringAttribute'
-            ? draft.attributes
-            : draft.encodedAttributes;
+        draft.paragraphStyle = draft.paragraphStyle ?? {
+          _class: 'paragraphStyle',
+          alignment: 0,
+        };
 
-        if (!attributes) return;
-
-        const paragraphStyle =
-          attributes.paragraphStyle ||
-          ({
-            _class: 'paragraphStyle',
-            alignment: 0,
-          } as Sketch.ParagraphStyle);
-        paragraphStyle.maximumLineHeight = value;
-        paragraphStyle.maximumLineHeight = value;
-
-        attributes.paragraphStyle = paragraphStyle;
+        draft.paragraphStyle.maximumLineHeight = value;
+        draft.paragraphStyle.maximumLineHeight = value;
       });
     }
     case 'setTextParagraphSpacing': {
       const [, value] = action;
 
       return produce(state, (draft) => {
-        const attributes =
-          draft._class === 'stringAttribute'
-            ? draft.attributes
-            : draft.encodedAttributes;
+        draft.paragraphStyle = draft.paragraphStyle ?? {
+          _class: 'paragraphStyle',
+          alignment: 0,
+        };
 
-        if (!attributes) return;
-
-        const paragraphStyle =
-          attributes.paragraphStyle ||
-          ({
-            _class: 'paragraphStyle',
-            alignment: 0,
-          } as Sketch.ParagraphStyle);
-
-        paragraphStyle.paragraphSpacing = value;
-        paragraphStyle.paragraphSpacing = value;
-
-        attributes.paragraphStyle = paragraphStyle;
+        draft.paragraphStyle.paragraphSpacing = value;
       });
     }
     case 'setTextHorizontalAlignment': {
       const [, value] = action;
 
       return produce(state, (draft) => {
-        const attributes =
-          draft._class === 'stringAttribute'
-            ? draft.attributes
-            : draft.encodedAttributes;
+        draft.paragraphStyle = draft.paragraphStyle ?? {
+          _class: 'paragraphStyle',
+          alignment: 0,
+        };
 
-        if (!attributes) return;
-
-        const paragraphStyle =
-          attributes.paragraphStyle ||
-          ({
-            _class: 'paragraphStyle',
-            alignment: 0,
-          } as Sketch.ParagraphStyle);
-
-        paragraphStyle.alignment = value;
-        attributes.paragraphStyle = paragraphStyle;
+        draft.paragraphStyle.alignment = value;
       });
     }
     case 'setTextVerticalAlignment': {
       const [, value] = action;
 
       return produce(state, (draft) => {
-        const attributes =
-          draft._class === 'stringAttribute'
-            ? draft.attributes
-            : draft.encodedAttributes;
-
-        if (!attributes) return;
-        attributes.textStyleVerticalAlignmentKey = value;
-
-        if (draft._class !== 'stringAttribute') draft.verticalAlignment = value;
+        draft.textStyleVerticalAlignmentKey = value;
       });
     }
     default:


### PR DESCRIPTION
I've updated the stringAttributeReducer to use an interface type that's common to both text styles and string attributes.

I also unified the `SimpleTextDecoration` style and improved naming consistency.