### PR TITLE
Render theme components using canvas

### DIFF
--- a/packages/app/src/components/theme/CanvasGridItem.tsx
+++ b/packages/app/src/components/theme/CanvasGridItem.tsx
@@ -1,0 +1,55 @@
+import { Size } from 'noya-geometry';
+import React, { memo, ReactNode, useCallback, useRef } from 'react';
+import styled from 'styled-components';
+import CanvasViewer from '../../containers/CanvasViewer';
+import { useSize } from '../../hooks/useSize';
+
+const Container = styled.div<{ backgroundColor?: string }>(
+  ({ backgroundColor }) => ({
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    borderRadius: '12px',
+    overflow: 'hidden',
+    ...(backgroundColor && { backgroundColor }),
+  }),
+);
+
+const Inner = styled.div({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+});
+
+interface Props {
+  renderContent: (size: Size) => ReactNode;
+  backgroundColor?: string;
+}
+
+export default memo(function CanvasGridItem({
+  renderContent,
+  backgroundColor,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const size = useSize(containerRef);
+  const renderer = useCallback(() => (size ? renderContent(size) : null), [
+    renderContent,
+    size,
+  ]);
+
+  return (
+    <Container ref={containerRef} backgroundColor={backgroundColor}>
+      <Inner>
+        {size && (
+          <CanvasViewer
+            width={size.width}
+            height={size.height}
+            renderContent={renderer}
+          />
+        )}
+      </Inner>
+    </Container>
+  );
+});

--- a/packages/app/src/components/theme/ColorSwatch.tsx
+++ b/packages/app/src/components/theme/ColorSwatch.tsx
@@ -1,22 +1,48 @@
 import Sketch from '@sketch-hq/sketch-file-format-ts';
-import { memo, useMemo } from 'react';
-import styled from 'styled-components';
 import { sketchColorToRgbaString } from 'noya-designsystem';
+import { Size } from 'noya-geometry';
+import {
+  Path,
+  useColorFill,
+  useDeletable,
+  useReactCanvasKit,
+} from 'noya-react-canvaskit';
+import React, { memo, useMemo } from 'react';
+import CanvasViewer from '../../containers/CanvasViewer';
 
-const ColoredCircle = styled.div(({ theme, color }) => ({
-  height: '65px',
-  width: '65px',
-  backgroundColor: color,
-  borderRadius: '50%',
-  border: '1px solid rgba(0,0,0,0.1)',
-}));
+const PREVIEW_SIZE = 60;
 
 interface Props {
   value: Sketch.Color;
 }
 
+function RCKColorSwatch({ color, size }: { color: string; size: Size }) {
+  const { CanvasKit } = useReactCanvasKit();
+  const fill = useColorFill(color);
+
+  const path = useMemo(() => {
+    const path = new CanvasKit.Path();
+    path.addOval(CanvasKit.XYWHRect(0, 0, size.width, size.height));
+    return path;
+  }, [CanvasKit, size]);
+
+  useDeletable(path);
+
+  return <Path path={path} paint={fill} />;
+}
+
 export default memo(function ColorSwatch({ value }: Props) {
   const colorString = useMemo(() => sketchColorToRgbaString(value), [value]);
+  const size = useMemo(
+    () => ({ width: PREVIEW_SIZE, height: PREVIEW_SIZE }),
+    [],
+  );
 
-  return <ColoredCircle color={colorString} />;
+  return (
+    <CanvasViewer
+      width={size.width}
+      height={size.height}
+      renderContent={() => <RCKColorSwatch color={colorString} size={size} />}
+    />
+  );
 });

--- a/packages/app/src/components/theme/TextStylesGrid.tsx
+++ b/packages/app/src/components/theme/TextStylesGrid.tsx
@@ -79,18 +79,10 @@ export default memo(function TextStylesGrid({
             {group.items.map((item) => {
               const text = delimitedPath.basename(item.name);
               const encoded = item.value.textStyle?.encodedAttributes;
-              const color = encoded?.MSAttributedStringColorAttribute;
-              const textTransform =
-                encoded?.MSAttributedStringTextTransformAttribute;
               const attributes =
                 encoded?.MSAttributedStringFontAttribute.attributes;
 
-              const textDecoration = encoded?.underlineStyle
-                ? 'underline'
-                : encoded?.strikethroughStyle
-                ? 'strikethrough'
-                : 'none';
-              if (!attributes || !color) return null;
+              if (!attributes) return null;
 
               const [font, weight] = attributes.name
                 .replace('MT', '')
@@ -115,13 +107,7 @@ export default memo(function TextStylesGrid({
                     )
                   }
                 >
-                  <TextStyle
-                    text={text}
-                    size={attributes.size}
-                    color={color}
-                    textDecoration={textDecoration}
-                    textTransform={textTransform}
-                  />
+                  <TextStyle name={text} style={item.value} />
                 </GridView.Item>
               );
             })}

--- a/packages/app/src/components/theme/ThemeStyle.tsx
+++ b/packages/app/src/components/theme/ThemeStyle.tsx
@@ -1,103 +1,41 @@
 import Sketch from '@sketch-hq/sketch-file-format-ts';
-import { memo, useMemo } from 'react';
-import styled from 'styled-components';
-import { sketchColorToRgbaString } from 'noya-designsystem';
+import produce from 'immer';
+import { Size } from 'noya-geometry';
+import { uuid } from 'noya-renderer';
+import SketchLayer from 'noya-renderer/src/components/layers/SketchLayer';
+import { Models } from 'noya-state';
+import React, { memo, useMemo } from 'react';
+import CanvasGridItem from './CanvasGridItem';
 
 interface Props {
   style: Sketch.Style;
 }
 
-interface SharedStyleProps {
-  border: string;
-  background: string;
-  shadow: string;
-  opacity: number;
+const PREVIEW_SIZE = 60;
+
+function RCKStylePreview({ style, size }: { style: Sketch.Style; size: Size }) {
+  const layer = useMemo(() => {
+    return produce(Models.rectangle, (draft) => {
+      draft.do_objectID = uuid();
+      draft.fixedRadius = 6;
+      draft.frame = {
+        ...draft.frame,
+        x: (size.width - PREVIEW_SIZE) / 2,
+        y: (size.height - PREVIEW_SIZE) / 2,
+        width: PREVIEW_SIZE,
+        height: PREVIEW_SIZE,
+      };
+      draft.style = style;
+    });
+  }, [style, size]);
+
+  return <SketchLayer layer={layer} />;
 }
 
-const LayerStyle = styled.div(
-  ({ border, background, shadow, opacity }: SharedStyleProps) => ({
-    height: '65px',
-    width: '65px',
-    border: border,
-    borderRadius: '10px',
-    background: background,
-    boxShadow: shadow,
-    opacity: opacity,
-  }),
-);
-
-export default memo(function SharedStyle({ style }: Props) {
-  const enabledBorders = useMemo(
-    () => style.borders?.filter((border) => border.isEnabled),
-    [style],
-  );
-
-  const boxShadow = useMemo(() => {
-    let boxshadow = '';
-    if (style.shadows && style.shadows.length) {
-      const shadow = style.shadows[0];
-      const innerShadow =
-        style.innerShadows && style.innerShadows.length
-          ? `inset ${style.innerShadows[0].offsetX}px ${
-              style.innerShadows[0].offsetY
-            }px ${sketchColorToRgbaString(style.innerShadows[0].color)}`
-          : '';
-
-      boxshadow = `${shadow.offsetX}px ${
-        shadow.offsetY
-      }px ${sketchColorToRgbaString(shadow.color)} ${innerShadow}}`;
-    }
-    if (enabledBorders && enabledBorders.length > 1) {
-      const border = enabledBorders.map((border, index, array) => {
-        const previousBorder = index > 0 ? array[index - 1].thickness : 0;
-        return `0 0 0 ${
-          border.thickness + previousBorder
-        }px ${sketchColorToRgbaString(border.color)}`;
-      });
-
-      return boxshadow + (boxshadow === '' ? '' : ',') + border.join(',');
-    }
-    return boxshadow;
-  }, [style, enabledBorders]);
-
-  const border = useMemo(() => {
-    if (enabledBorders && enabledBorders.length === 1) {
-      const border = enabledBorders[0];
-      return `${border.thickness}px solid ${sketchColorToRgbaString(
-        border.color,
-      )}`;
-    }
-
-    return '';
-  }, [enabledBorders]);
-
-  const background = useMemo(
-    () =>
-      style.fills
-        ? style.fills
-            .filter((e) => e.isEnabled)
-            .map(
-              (e) =>
-                `linear-gradient(
-                  ${sketchColorToRgbaString(e.color)}, 
-                  ${sketchColorToRgbaString(e.color)})`,
-            )
-            .join(',')
-        : '',
-    [style],
-  );
-
-  const opacity = useMemo(
-    () => (style.contextSettings ? style.contextSettings.opacity : 1),
-    [style],
-  );
-
+export default memo(function ThemeStyle({ style }: Props) {
   return (
-    <LayerStyle
-      border={border}
-      background={background}
-      shadow={boxShadow}
-      opacity={opacity}
+    <CanvasGridItem
+      renderContent={(size) => <RCKStylePreview style={style} size={size} />}
     />
   );
 });

--- a/packages/noya-geometry/src/types.ts
+++ b/packages/noya-geometry/src/types.ts
@@ -1,5 +1,7 @@
 export type Point = { x: number; y: number };
 
+export type Size = { width: number; height: number };
+
 export type Rect = { x: number; y: number; width: number; height: number };
 
 export type Bounds = {

--- a/packages/noya-renderer/src/components/layers/SketchText.tsx
+++ b/packages/noya-renderer/src/components/layers/SketchText.tsx
@@ -2,6 +2,7 @@ import Sketch from '@sketch-hq/sketch-file-format-ts';
 import {
   Group,
   Text,
+  useDeletable,
   useFontManager,
   useReactCanvasKit,
 } from 'noya-react-canvaskit';
@@ -44,7 +45,7 @@ function applyTextTransform(text: string, transform: Sketch.TextTransform) {
   }
 }
 
-export default memo(function SketchText({ layer }: Props) {
+export function useTextLayerParagraph(layer: Sketch.Text) {
   const { CanvasKit } = useReactCanvasKit();
   const fontManager = useFontManager();
 
@@ -104,6 +105,9 @@ export default memo(function SketchText({ layer }: Props) {
     });
 
     const paragraph = builder.build();
+
+    builder.delete();
+
     paragraph.layout(layer.frame.width);
 
     return paragraph;
@@ -120,12 +124,22 @@ export default memo(function SketchText({ layer }: Props) {
     textTransform,
   ]);
 
-  const element = (
-    <Text
-      paragraph={paragraph}
-      rect={Primitives.rect(CanvasKit, layer.frame)}
-    />
-  );
+  useDeletable(paragraph);
+
+  return paragraph;
+}
+
+export default memo(function SketchText({ layer }: Props) {
+  const { CanvasKit } = useReactCanvasKit();
+
+  const paragraph = useTextLayerParagraph(layer);
+
+  const rect = useMemo(() => Primitives.rect(CanvasKit, layer.frame), [
+    CanvasKit,
+    layer.frame,
+  ]);
+
+  const element = <Text paragraph={paragraph} rect={rect} />;
 
   const opacity = layer.style?.contextSettings?.opacity ?? 1;
 

--- a/packages/noya-state/src/index.ts
+++ b/packages/noya-state/src/index.ts
@@ -1,3 +1,7 @@
+import { setAutoFreeze } from 'immer';
+
+setAutoFreeze(false);
+
 export * as Layers from './layers';
 export * as Selectors from './selectors/selectors';
 export * as Models from './models';

--- a/packages/noya-state/src/models/textStyle.json
+++ b/packages/noya-state/src/models/textStyle.json
@@ -43,8 +43,8 @@
       "MSAttributedStringFontAttribute": {
         "_class": "fontDescriptor",
         "attributes": {
-          "name": "Arial",
-          "size": 12
+          "name": "Helvetica",
+          "size": 18
         }
       },
       "MSAttributedStringColorAttribute": {
@@ -53,6 +53,11 @@
         "blue": 0,
         "green": 0,
         "red": 0
+      },
+      "textStyleVerticalAlignmentKey": 0,
+      "paragraphStyle": {
+        "_class": "paragraphStyle",
+        "alignment": 0
       }
     }
   },

--- a/packages/noya-state/src/reducers/textStyleReducer.ts
+++ b/packages/noya-state/src/reducers/textStyleReducer.ts
@@ -57,10 +57,8 @@ export function textStyleReducer(
                 action,
               );
 
-              layer.attributedString.attributes.forEach((attribute, index) => {
-                layer.attributedString.attributes[
-                  index
-                ].attributes = stringAttributeReducer(
+              layer.attributedString.attributes.forEach((attribute) => {
+                attribute.attributes = stringAttributeReducer(
                   attribute.attributes,
                   action,
                 );

--- a/packages/noya-state/src/selectors/textStyleSelectors.ts
+++ b/packages/noya-state/src/selectors/textStyleSelectors.ts
@@ -18,7 +18,7 @@ function getTextStyleColor(encodedAttributes: EncodedAttribute) {
 function getTextFontFamily(encodedAttributes: EncodedAttribute) {
   return (
     encodedAttributes?.MSAttributedStringFontAttribute.attributes.name ??
-    'Arial'
+    'Helvetica'
   );
 }
 


### PR DESCRIPTION
This updates the theme tab to use the canvas for previewing. This improves preview accuracy, and is necessary for previewing symbols.

![Screen Shot 2021-05-14 at 11 06 01 AM](https://user-images.githubusercontent.com/1198882/118311154-6100a300-b4a4-11eb-917d-b15c18b8f56a.png)

![Screen Shot 2021-05-14 at 11 07 43 AM](https://user-images.githubusercontent.com/1198882/118311326-9e653080-b4a4-11eb-8515-5786d74b4554.png)

![Screen Shot 2021-05-14 at 11 08 27 AM](https://user-images.githubusercontent.com/1198882/118311410-b8067800-b4a4-11eb-92df-76380240a781.png)

@milg15 