### PR TITLE
Quick measure abstraction

### DIFF
--- a/packages/noya-renderer/src/components/DistanceLabelAndPath.tsx
+++ b/packages/noya-renderer/src/components/DistanceLabelAndPath.tsx
@@ -122,7 +122,8 @@ function getGuides(
 
   let edge = isFurther(selected[minM], highlighted[maxM])
     ? highlighted[maxM]
-    : isFurther(selected[maxM], highlighted[maxM])
+    : isFurther(selected[maxM], highlighted[maxM]) ||
+      isFurther(selected[minM], highlighted[minM])
     ? highlighted[minM]
     : undefined;
 


### PR DESCRIPTION
This adds an abstraction for determining all 4 sets of guides with a single function.

We separately find guides for each direction: `+x`, `-x`, `+y`, `-y`.  We use flexbox naming for the 2 axes: "main axis" and "cross axis". These are abbreviated as `m` and `c` so the code is more concise, which I think makes it a little easier to read

@leannepepper 