### PR TITLE
Export preview

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,6 +6,7 @@
     "@dnd-kit/core": "^1.0.1",
     "@dnd-kit/modifiers": "^1.0.1",
     "@dnd-kit/sortable": "^1.0.1",
+    "@radix-ui/react-aspect-ratio": "^0.0.14",
     "@radix-ui/react-icons": "^1.0.1",
     "browser-fs-access": "^0.17.2",
     "kiwi.js": "^1.1.2",

--- a/packages/app/src/components/inspector/ExportPreviewRow.tsx
+++ b/packages/app/src/components/inspector/ExportPreviewRow.tsx
@@ -1,8 +1,8 @@
 import * as AspectRatio from '@radix-ui/react-aspect-ratio';
 import { memo, useCallback } from 'react';
+import { LayerPreview } from 'noya-renderer';
 import { PageLayer } from '../../../../noya-state/src';
 import CanvasGridItem from '../theme/CanvasGridItem';
-import { RCKLayerPreview } from '../theme/Symbol';
 
 function createCheckerBackground(
   size: number,
@@ -50,7 +50,7 @@ export default memo(function ExportPreviewRow({ layer }: Props) {
         background={createCheckerBackground(7, 'rgba(255,255,255,0.1)')}
         renderContent={useCallback(
           (size) => (
-            <RCKLayerPreview layer={layer} size={size} />
+            <LayerPreview layer={layer} size={size} />
           ),
           [layer],
         )}

--- a/packages/app/src/components/inspector/ExportPreviewRow.tsx
+++ b/packages/app/src/components/inspector/ExportPreviewRow.tsx
@@ -50,7 +50,7 @@ export default memo(function ExportPreviewRow({ layer }: Props) {
         background={createCheckerBackground(7, 'rgba(255,255,255,0.1)')}
         renderContent={useCallback(
           (size) => (
-            <RCKLayerPreview layer={layer} size={size} padding={0} />
+            <RCKLayerPreview layer={layer} size={size} />
           ),
           [layer],
         )}

--- a/packages/app/src/components/inspector/ExportPreviewRow.tsx
+++ b/packages/app/src/components/inspector/ExportPreviewRow.tsx
@@ -1,26 +1,63 @@
+import * as AspectRatio from '@radix-ui/react-aspect-ratio';
 import Sketch from '@sketch-hq/sketch-file-format-ts';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
+import * as InspectorPrimitives from '../inspector/InspectorPrimitives';
 import CanvasGridItem from '../theme/CanvasGridItem';
 import { RCKSymbolPreview } from '../theme/Symbol';
-import styled from 'styled-components';
 
-const Row = styled.div(({ theme }) => ({
-  flex: '1',
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-}));
+function createCheckerBackground(
+  size: number,
+  color1: string,
+  color2: string = 'transparent',
+) {
+  const sizePx = `${size}px`;
+
+  const backgrounds = [
+    {
+      position: '0 0',
+      size: `calc(${sizePx} * 2) calc(${sizePx} * 2)`,
+      image: `linear-gradient(45deg, ${color1} 25%, ${color2} 25%)`,
+    },
+    {
+      position: `0 ${sizePx}`,
+      size: `calc(${sizePx} * 2) calc(${sizePx} * 2)`,
+      image: `linear-gradient(-45deg, ${color1} 25%, ${color2} 25%)`,
+    },
+    {
+      position: `${sizePx} calc(${sizePx} * -1)`,
+      size: `calc(${sizePx} * 2) calc(${sizePx} * 2)`,
+      image: `linear-gradient(45deg, ${color2} 75%, ${color1} 75%)`,
+    },
+    {
+      position: `calc(${sizePx} * -1) 0px`,
+      size: `calc(${sizePx} * 2) calc(${sizePx} * 2)`,
+      image: `linear-gradient(-45deg, ${color2} 75%, ${color1} 75%)`,
+    },
+  ];
+
+  return backgrounds
+    .map((item) => `${item.position} / ${item.size} ${item.image}`)
+    .join(', ');
+}
 
 interface Props {
   layer: Sketch.SymbolMaster;
 }
 
-export default memo(function NameInspector({ layer }: Props) {
+export default memo(function ExportPreviewRow({ layer }: Props) {
   return (
-    <Row>
-      <CanvasGridItem
-        renderContent={(size) => <RCKSymbolPreview layer={layer} size={size} />}
-      />
-    </Row>
+    <InspectorPrimitives.Section>
+      <AspectRatio.Root>
+        <CanvasGridItem
+          background={createCheckerBackground(7, 'rgba(255,255,255,0.1)')}
+          renderContent={useCallback(
+            (size) => (
+              <RCKSymbolPreview layer={layer} size={size} />
+            ),
+            [layer],
+          )}
+        />
+      </AspectRatio.Root>
+    </InspectorPrimitives.Section>
   );
 });

--- a/packages/app/src/components/inspector/ExportPreviewRow.tsx
+++ b/packages/app/src/components/inspector/ExportPreviewRow.tsx
@@ -1,6 +1,6 @@
 import * as AspectRatio from '@radix-ui/react-aspect-ratio';
 import { memo, useCallback } from 'react';
-import { LayerPreview } from 'noya-renderer';
+import { LayerPreview as RCKLayerPreview } from 'noya-renderer';
 import { PageLayer } from '../../../../noya-state/src';
 import CanvasGridItem from '../theme/CanvasGridItem';
 
@@ -16,7 +16,11 @@ export default memo(function ExportPreviewRow({ layer }: Props) {
       <CanvasGridItem
         renderContent={useCallback(
           (size) => (
-            <LayerPreview layer={layer} size={size} showCheckeredBackground />
+            <RCKLayerPreview
+              layer={layer}
+              size={size}
+              showCheckeredBackground
+            />
           ),
           [layer],
         )}

--- a/packages/app/src/components/inspector/ExportPreviewRow.tsx
+++ b/packages/app/src/components/inspector/ExportPreviewRow.tsx
@@ -1,9 +1,8 @@
 import * as AspectRatio from '@radix-ui/react-aspect-ratio';
-import Sketch from '@sketch-hq/sketch-file-format-ts';
 import { memo, useCallback } from 'react';
-import * as InspectorPrimitives from '../inspector/InspectorPrimitives';
+import { PageLayer } from '../../../../noya-state/src';
 import CanvasGridItem from '../theme/CanvasGridItem';
-import { RCKSymbolPreview } from '../theme/Symbol';
+import { RCKLayerPreview } from '../theme/Symbol';
 
 function createCheckerBackground(
   size: number,
@@ -41,23 +40,21 @@ function createCheckerBackground(
 }
 
 interface Props {
-  layer: Sketch.SymbolMaster;
+  layer: PageLayer;
 }
 
 export default memo(function ExportPreviewRow({ layer }: Props) {
   return (
-    <InspectorPrimitives.Section>
-      <AspectRatio.Root>
-        <CanvasGridItem
-          background={createCheckerBackground(7, 'rgba(255,255,255,0.1)')}
-          renderContent={useCallback(
-            (size) => (
-              <RCKSymbolPreview layer={layer} size={size} />
-            ),
-            [layer],
-          )}
-        />
-      </AspectRatio.Root>
-    </InspectorPrimitives.Section>
+    <AspectRatio.Root>
+      <CanvasGridItem
+        background={createCheckerBackground(7, 'rgba(255,255,255,0.1)')}
+        renderContent={useCallback(
+          (size) => (
+            <RCKLayerPreview layer={layer} size={size} padding={0} />
+          ),
+          [layer],
+        )}
+      />
+    </AspectRatio.Root>
   );
 });

--- a/packages/app/src/components/inspector/ExportPreviewRow.tsx
+++ b/packages/app/src/components/inspector/ExportPreviewRow.tsx
@@ -4,53 +4,19 @@ import { LayerPreview } from 'noya-renderer';
 import { PageLayer } from '../../../../noya-state/src';
 import CanvasGridItem from '../theme/CanvasGridItem';
 
-function createCheckerBackground(
-  size: number,
-  color1: string,
-  color2: string = 'transparent',
-) {
-  const sizePx = `${size}px`;
-
-  const backgrounds = [
-    {
-      position: '0 0',
-      size: `calc(${sizePx} * 2) calc(${sizePx} * 2)`,
-      image: `linear-gradient(45deg, ${color1} 25%, ${color2} 25%)`,
-    },
-    {
-      position: `0 ${sizePx}`,
-      size: `calc(${sizePx} * 2) calc(${sizePx} * 2)`,
-      image: `linear-gradient(-45deg, ${color1} 25%, ${color2} 25%)`,
-    },
-    {
-      position: `${sizePx} calc(${sizePx} * -1)`,
-      size: `calc(${sizePx} * 2) calc(${sizePx} * 2)`,
-      image: `linear-gradient(45deg, ${color2} 75%, ${color1} 75%)`,
-    },
-    {
-      position: `calc(${sizePx} * -1) 0px`,
-      size: `calc(${sizePx} * 2) calc(${sizePx} * 2)`,
-      image: `linear-gradient(-45deg, ${color2} 75%, ${color1} 75%)`,
-    },
-  ];
-
-  return backgrounds
-    .map((item) => `${item.position} / ${item.size} ${item.image}`)
-    .join(', ');
-}
-
 interface Props {
   layer: PageLayer;
 }
 
 export default memo(function ExportPreviewRow({ layer }: Props) {
   return (
-    <AspectRatio.Root>
+    <AspectRatio.Root
+      ratio={Math.max(1, layer.frame.width / layer.frame.height)}
+    >
       <CanvasGridItem
-        background={createCheckerBackground(7, 'rgba(255,255,255,0.1)')}
         renderContent={useCallback(
           (size) => (
-            <LayerPreview layer={layer} size={size} />
+            <LayerPreview layer={layer} size={size} showCheckeredBackground />
           ),
           [layer],
         )}

--- a/packages/app/src/components/theme/CanvasGridItem.tsx
+++ b/packages/app/src/components/theme/CanvasGridItem.tsx
@@ -4,15 +4,13 @@ import styled from 'styled-components';
 import CanvasViewer from '../../containers/CanvasViewer';
 import { useSize } from '../../hooks/useSize';
 
-const Container = styled.div<{ backgroundColor?: string }>(
-  ({ backgroundColor }) => ({
-    position: 'relative',
-    width: '100%',
-    height: '100%',
-    overflow: 'hidden',
-    ...(backgroundColor && { backgroundColor }),
-  }),
-);
+const Container = styled.div<{ background?: string }>(({ background }) => ({
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+  overflow: 'hidden',
+  ...(background && { background }),
+}));
 
 const Inner = styled.div({
   position: 'absolute',
@@ -24,12 +22,12 @@ const Inner = styled.div({
 
 interface Props {
   renderContent: (size: Size) => ReactNode;
-  backgroundColor?: string;
+  background?: string;
 }
 
 export default memo(function CanvasGridItem({
   renderContent,
-  backgroundColor,
+  background,
 }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const size = useSize(containerRef);
@@ -39,7 +37,7 @@ export default memo(function CanvasGridItem({
   ]);
 
   return (
-    <Container ref={containerRef} backgroundColor={backgroundColor}>
+    <Container ref={containerRef} background={background}>
       <Inner>
         {size && (
           <CanvasViewer

--- a/packages/app/src/components/theme/Symbol.tsx
+++ b/packages/app/src/components/theme/Symbol.tsx
@@ -18,7 +18,7 @@ interface Props {
 export function RCKLayerPreview({
   layer,
   size,
-  padding = 10,
+  padding = 0,
 }: {
   layer: PageLayer;
   size: Size;
@@ -86,7 +86,9 @@ export function RCKLayerPreview({
 export default memo(function Symbol({ layer }: Props) {
   return (
     <CanvasGridItem
-      renderContent={(size) => <RCKLayerPreview layer={layer} size={size} />}
+      renderContent={(size) => (
+        <RCKLayerPreview layer={layer} size={size} padding={10} />
+      )}
     />
   );
 });

--- a/packages/app/src/components/theme/Symbol.tsx
+++ b/packages/app/src/components/theme/Symbol.tsx
@@ -1,93 +1,17 @@
 import Sketch from '@sketch-hq/sketch-file-format-ts';
-import {
-  AffineTransform,
-  createBounds,
-  resizeIfLarger,
-  Size,
-} from 'noya-geometry';
-import { Group } from 'noya-react-canvaskit';
-import { SketchGroup, SketchLayer } from 'noya-renderer';
-import { Layers, PageLayer } from 'noya-state';
-import { memo, useMemo } from 'react';
+import { LayerPreview } from 'noya-renderer';
+import { memo } from 'react';
 import CanvasGridItem from './CanvasGridItem';
 
 interface Props {
   layer: Sketch.SymbolMaster;
 }
 
-export function RCKLayerPreview({
-  layer,
-  size,
-  padding = 0,
-}: {
-  layer: PageLayer;
-  size: Size;
-  padding?: number;
-}) {
-  const bounds = useMemo(() => createBounds(layer.frame), [layer.frame]);
-
-  const paddedSize = useMemo(
-    () => ({
-      width: size.width - padding * 2,
-      height: size.height - padding * 2,
-    }),
-    [padding, size.height, size.width],
-  );
-
-  const layerSize = useMemo(
-    () => ({ width: layer.frame.width, height: layer.frame.height }),
-    [layer.frame.height, layer.frame.width],
-  );
-
-  const scaledRect = useMemo(() => resizeIfLarger(layerSize, paddedSize), [
-    layerSize,
-    paddedSize,
-  ]);
-
-  const transform = useMemo(() => {
-    // Scale down to fit, if needed
-    const scale = Math.min(
-      1,
-      Math.max(
-        scaledRect.width / layerSize.width,
-        scaledRect.height / layerSize.height,
-      ),
-    );
-
-    return AffineTransform.multiply(
-      // Translate to the center of the size
-      AffineTransform.translation(size.width / 2, size.height / 2),
-      AffineTransform.scale(scale),
-      // Translate to (0,0) before scaling, since scale is applied at the origin
-      AffineTransform.translation(-bounds.midX, -bounds.midY),
-    );
-  }, [
-    scaledRect.width,
-    scaledRect.height,
-    layerSize.width,
-    layerSize.height,
-    size.width,
-    size.height,
-    bounds.midX,
-    bounds.midY,
-  ]);
-
-  return (
-    <Group transform={transform}>
-      {Layers.isSymbolMasterOrArtboard(layer) ? (
-        <SketchGroup layer={layer} />
-      ) : (
-        <SketchLayer layer={layer} />
-      )}
-    </Group>
-  );
-}
-
 export default memo(function Symbol({ layer }: Props) {
   return (
     <CanvasGridItem
       renderContent={(size) => (
-        <RCKLayerPreview layer={layer} size={size} padding={10} />
+        <LayerPreview layer={layer} size={size} padding={10} />
       )}
     />
   );

--- a/packages/app/src/components/theme/Symbol.tsx
+++ b/packages/app/src/components/theme/Symbol.tsx
@@ -11,7 +11,12 @@ export default memo(function Symbol({ layer }: Props) {
   return (
     <CanvasGridItem
       renderContent={(size) => (
-        <LayerPreview layer={layer} size={size} padding={10} />
+        <LayerPreview
+          layer={layer}
+          size={size}
+          padding={10}
+          scalingMode="down"
+        />
       )}
     />
   );

--- a/packages/app/src/components/theme/Symbol.tsx
+++ b/packages/app/src/components/theme/Symbol.tsx
@@ -1,5 +1,5 @@
 import Sketch from '@sketch-hq/sketch-file-format-ts';
-import { LayerPreview } from 'noya-renderer';
+import { LayerPreview as RCKLayerPreview } from 'noya-renderer';
 import { memo } from 'react';
 import CanvasGridItem from './CanvasGridItem';
 
@@ -11,7 +11,7 @@ export default memo(function Symbol({ layer }: Props) {
   return (
     <CanvasGridItem
       renderContent={(size) => (
-        <LayerPreview
+        <RCKLayerPreview
           layer={layer}
           size={size}
           padding={10}

--- a/packages/app/src/components/theme/TextStyle.tsx
+++ b/packages/app/src/components/theme/TextStyle.tsx
@@ -100,7 +100,7 @@ export default memo(function TextStyle({ name, style }: Props) {
 
   return (
     <CanvasGridItem
-      backgroundColor={backgroundColor}
+      background={backgroundColor}
       renderContent={(size) => (
         <RCKTextStylePreview name={name} style={style} size={size} />
       )}

--- a/packages/app/src/containers/CanvasViewer.tsx
+++ b/packages/app/src/containers/CanvasViewer.tsx
@@ -1,7 +1,3 @@
-import type { CanvasKit } from 'canvaskit';
-import { Theme } from 'noya-designsystem';
-import { render, unmount } from 'noya-react-canvaskit';
-import { WorkspaceState } from 'noya-state';
 import React, {
   memo,
   ReactNode,
@@ -9,55 +5,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { ThemeProvider, useTheme } from 'styled-components';
-import {
-  StateProvider,
-  useWorkspaceState,
-} from '../contexts/ApplicationStateContext';
+import { useTheme } from 'styled-components';
+import { useWorkspaceState } from '../contexts/ApplicationStateContext';
 import useCanvasKit from '../hooks/useCanvasKit';
-
-function renderImageFromCanvas(
-  CanvasKit: CanvasKit,
-  width: number,
-  height: number,
-  theme: Theme,
-  state: WorkspaceState,
-  renderContent: () => ReactNode,
-): Promise<Uint8Array | undefined> {
-  const surface = CanvasKit.MakeSurface(width, height);
-
-  if (!surface) {
-    console.warn('failed to create surface');
-    return Promise.resolve(undefined);
-  }
-
-  return new Promise((resolve) => {
-    const root = (
-      <ThemeProvider theme={theme}>
-        <StateProvider state={state}>{renderContent()}</StateProvider>
-      </ThemeProvider>
-    );
-
-    render(root, surface, CanvasKit, () => {
-      const image = surface.makeImageSnapshot();
-
-      const colorSpace = image.getColorSpace();
-
-      const bytes = image.readPixels(0, 0, {
-        ...image.getImageInfo(),
-        colorSpace: image.getColorSpace(),
-      }) as Uint8Array;
-
-      colorSpace.delete();
-
-      unmount(surface, () => {
-        resolve(bytes);
-
-        surface.delete();
-      });
-    });
-  });
-}
+import { renderImageFromCanvas } from '../utils/renderImageFromCanvas';
 
 interface Props {
   width: number;
@@ -85,6 +36,7 @@ export default memo(function CanvasViewer({
       height,
       theme,
       rawApplicationState,
+      'bytes',
       renderContent,
     ).then((bytes) => {
       if (!valid || !bytes) return;

--- a/packages/app/src/containers/ExportInspector.tsx
+++ b/packages/app/src/containers/ExportInspector.tsx
@@ -1,25 +1,47 @@
+import type FileFormat from '@sketch-hq/sketch-file-format-ts';
 import Sketch from '@sketch-hq/sketch-file-format-ts';
+import { fileSave } from 'browser-fs-access';
+import { Button, Divider, Spacer } from 'noya-designsystem';
+import withSeparatorElements from 'noya-designsystem/src/utils/withSeparatorElements';
 import { Selectors } from 'noya-state';
 import { memo, useCallback } from 'react';
-import { useSelector, useDispatch } from '../contexts/ApplicationStateContext';
-import withSeparatorElements from 'noya-designsystem/src/utils/withSeparatorElements';
-import { Divider } from 'noya-designsystem';
-import type FileFormat from '@sketch-hq/sketch-file-format-ts';
+import { useTheme } from 'styled-components';
 import ArrayController from '../components/inspector/ExportArrayController';
 import ExportFormatsRow from '../components/inspector/ExportFormatsRow';
 import ExportPreviewRow from '../components/inspector/ExportPreviewRow';
+import * as InspectorPrimitives from '../components/inspector/InspectorPrimitives';
+import { RCKLayerPreview } from '../components/theme/Symbol';
+import {
+  useDispatch,
+  useGetWorkspaceStateSnapshot,
+  useSelector,
+} from '../contexts/ApplicationStateContext';
+import useCanvasKit from '../hooks/useCanvasKit';
+import { renderImageFromCanvas } from '../utils/renderImageFromCanvas';
+
+async function saveFile(name: string, data: Uint8Array) {
+  const file = new File([data], name, {
+    type: 'application/zip',
+  });
+
+  await fileSave(
+    file,
+    { fileName: file.name, extensions: ['.png'] },
+    undefined,
+    false,
+  );
+}
 
 export default memo(function ExportInspector() {
   const title = 'Exports';
   const dispatch = useDispatch();
+  const theme = useTheme();
+  const CanvasKit = useCanvasKit();
+  const getWorkspaceStateSnapshot = useGetWorkspaceStateSnapshot();
 
   const selectedLayer = useSelector(
     Selectors.getSelectedLayers,
   )[0] as Sketch.SymbolInstance;
-
-  const symbolMaster = useSelector(Selectors.getSymbols).find(
-    (symbol: Sketch.SymbolMaster) => symbol.symbolID === selectedLayer.symbolID,
-  );
 
   const exportFormats = selectedLayer.exportOptions.exportFormats;
 
@@ -57,8 +79,39 @@ export default memo(function ExportInspector() {
         [exportFormats.length, dispatch],
       )}
     </ArrayController>,
-    exportFormats.length > 0 && symbolMaster && (
-      <ExportPreviewRow layer={symbolMaster} />
+    exportFormats.length > 0 && selectedLayer && (
+      <>
+        <InspectorPrimitives.Section>
+          <ExportPreviewRow layer={selectedLayer} />
+          <Spacer.Vertical size={10} />
+          <Button
+            id="export-selected"
+            onClick={async () => {
+              const bytes = await renderImageFromCanvas(
+                CanvasKit,
+                100,
+                100,
+                theme,
+                getWorkspaceStateSnapshot(),
+                'png',
+                () => (
+                  <RCKLayerPreview
+                    layer={selectedLayer}
+                    size={{ width: 100, height: 100 }}
+                    padding={0}
+                  />
+                ),
+              );
+
+              if (!bytes) return;
+
+              saveFile('test.png', bytes);
+            }}
+          >
+            Export Selected...
+          </Button>
+        </InspectorPrimitives.Section>
+      </>
     ),
   ];
 

--- a/packages/app/src/containers/ExportInspector.tsx
+++ b/packages/app/src/containers/ExportInspector.tsx
@@ -6,11 +6,11 @@ import withSeparatorElements from 'noya-designsystem/src/utils/withSeparatorElem
 import { Selectors } from 'noya-state';
 import { memo, useCallback } from 'react';
 import { useTheme } from 'styled-components';
+import { LayerPreview } from 'noya-renderer';
 import ArrayController from '../components/inspector/ExportArrayController';
 import ExportFormatsRow from '../components/inspector/ExportFormatsRow';
 import ExportPreviewRow from '../components/inspector/ExportPreviewRow';
 import * as InspectorPrimitives from '../components/inspector/InspectorPrimitives';
-import { RCKLayerPreview } from '../components/theme/Symbol';
 import {
   useDispatch,
   useGetWorkspaceStateSnapshot,
@@ -99,7 +99,7 @@ export default memo(function ExportInspector() {
                 theme,
                 getWorkspaceStateSnapshot(),
                 'png',
-                () => <RCKLayerPreview layer={selectedLayer} size={size} />,
+                () => <LayerPreview layer={selectedLayer} size={size} />,
               );
 
               if (!data) return;

--- a/packages/app/src/containers/ExportInspector.tsx
+++ b/packages/app/src/containers/ExportInspector.tsx
@@ -57,7 +57,9 @@ export default memo(function ExportInspector() {
         [exportFormats.length, dispatch],
       )}
     </ArrayController>,
-    symbolMaster && <ExportPreviewRow layer={symbolMaster} />,
+    exportFormats.length > 0 && symbolMaster && (
+      <ExportPreviewRow layer={symbolMaster} />
+    ),
   ];
 
   return <>{withSeparatorElements(elements, <Divider />)}</>;

--- a/packages/app/src/containers/ExportInspector.tsx
+++ b/packages/app/src/containers/ExportInspector.tsx
@@ -21,7 +21,7 @@ import { renderImageFromCanvas } from '../utils/renderImageFromCanvas';
 
 async function saveFile(name: string, data: Uint8Array) {
   const file = new File([data], name, {
-    type: 'application/zip',
+    type: 'image/png',
   });
 
   await fileSave(
@@ -87,25 +87,24 @@ export default memo(function ExportInspector() {
           <Button
             id="export-selected"
             onClick={async () => {
-              const bytes = await renderImageFromCanvas(
+              const size = {
+                width: Math.ceil(selectedLayer.frame.width),
+                height: Math.ceil(selectedLayer.frame.height),
+              };
+
+              const data = await renderImageFromCanvas(
                 CanvasKit,
-                100,
-                100,
+                size.width,
+                size.height,
                 theme,
                 getWorkspaceStateSnapshot(),
                 'png',
-                () => (
-                  <RCKLayerPreview
-                    layer={selectedLayer}
-                    size={{ width: 100, height: 100 }}
-                    padding={0}
-                  />
-                ),
+                () => <RCKLayerPreview layer={selectedLayer} size={size} />,
               );
 
-              if (!bytes) return;
+              if (!data) return;
 
-              saveFile('test.png', bytes);
+              saveFile(`${selectedLayer.name}.png`, data);
             }}
           >
             Export Selected...

--- a/packages/app/src/containers/ExportInspector.tsx
+++ b/packages/app/src/containers/ExportInspector.tsx
@@ -6,7 +6,7 @@ import withSeparatorElements from 'noya-designsystem/src/utils/withSeparatorElem
 import { Selectors } from 'noya-state';
 import { memo, useCallback } from 'react';
 import { useTheme } from 'styled-components';
-import { LayerPreview } from 'noya-renderer';
+import { LayerPreview as RCKLayerPreview } from 'noya-renderer';
 import ArrayController from '../components/inspector/ExportArrayController';
 import ExportFormatsRow from '../components/inspector/ExportFormatsRow';
 import ExportPreviewRow from '../components/inspector/ExportPreviewRow';
@@ -44,6 +44,28 @@ export default memo(function ExportInspector() {
   )[0] as Sketch.SymbolInstance;
 
   const exportFormats = selectedLayer.exportOptions.exportFormats;
+
+  // TODO: Handle export formats
+  const handleExport = useCallback(async () => {
+    const size = {
+      width: Math.ceil(selectedLayer.frame.width),
+      height: Math.ceil(selectedLayer.frame.height),
+    };
+
+    const data = await renderImageFromCanvas(
+      CanvasKit,
+      size.width,
+      size.height,
+      theme,
+      getWorkspaceStateSnapshot(),
+      'png',
+      () => <RCKLayerPreview layer={selectedLayer} size={size} />,
+    );
+
+    if (!data) return;
+
+    saveFile(`${selectedLayer.name}.png`, data);
+  }, [CanvasKit, getWorkspaceStateSnapshot, selectedLayer, theme]);
 
   const elements = [
     <ArrayController<FileFormat.ExportFormat>
@@ -84,29 +106,7 @@ export default memo(function ExportInspector() {
         <InspectorPrimitives.Section>
           <ExportPreviewRow layer={selectedLayer} />
           <Spacer.Vertical size={10} />
-          <Button
-            id="export-selected"
-            onClick={async () => {
-              const size = {
-                width: Math.ceil(selectedLayer.frame.width),
-                height: Math.ceil(selectedLayer.frame.height),
-              };
-
-              const data = await renderImageFromCanvas(
-                CanvasKit,
-                size.width,
-                size.height,
-                theme,
-                getWorkspaceStateSnapshot(),
-                'png',
-                () => <LayerPreview layer={selectedLayer} size={size} />,
-              );
-
-              if (!data) return;
-
-              saveFile(`${selectedLayer.name}.png`, data);
-            }}
-          >
+          <Button id="export-selected" onClick={handleExport}>
             Export Selected...
           </Button>
         </InspectorPrimitives.Section>

--- a/packages/app/src/contexts/ApplicationStateContext.tsx
+++ b/packages/app/src/contexts/ApplicationStateContext.tsx
@@ -108,7 +108,7 @@ export const useApplicationState = (): [ApplicationState, FlatDispatcher] => {
  * We do this to avoid excessively re-rendering components that need to access
  * the entire state in event handlers.
  */
-export const useGetStateSnapshot = (): (() => ApplicationState) => {
+export const useGetWorkspaceStateSnapshot = (): (() => WorkspaceState) => {
   const state = useWorkspaceState();
 
   const stateSnapshot = useRef<WorkspaceState>(state);
@@ -117,7 +117,15 @@ export const useGetStateSnapshot = (): (() => ApplicationState) => {
     stateSnapshot.current = state;
   }, [state]);
 
-  return useCallback(() => stateSnapshot.current.history.present, []);
+  return useCallback(() => stateSnapshot.current, []);
+};
+
+export const useGetStateSnapshot = (): (() => ApplicationState) => {
+  const getWorkspaceStateSnapshot = useGetWorkspaceStateSnapshot();
+
+  return useCallback(() => getWorkspaceStateSnapshot().history.present, [
+    getWorkspaceStateSnapshot,
+  ]);
 };
 
 export function useSelector<Projection>(

--- a/packages/app/src/utils/renderImageFromCanvas.tsx
+++ b/packages/app/src/utils/renderImageFromCanvas.tsx
@@ -1,0 +1,63 @@
+import type { CanvasKit, Image } from 'canvaskit';
+import { Theme } from 'noya-designsystem';
+import { render, unmount } from 'noya-react-canvaskit';
+import { WorkspaceState } from 'noya-state';
+import React, { ReactNode } from 'react';
+import { ThemeProvider } from 'styled-components';
+import { StateProvider } from '../contexts/ApplicationStateContext';
+
+function readPixels(image: Image): Uint8Array | null {
+  return image.readPixels(0, 0, {
+    ...image.getImageInfo(),
+    colorSpace: image.getColorSpace(),
+  }) as Uint8Array | null;
+}
+
+export function renderImageFromCanvas(
+  CanvasKit: CanvasKit,
+  width: number,
+  height: number,
+  theme: Theme,
+  state: WorkspaceState,
+  format: 'bytes' | 'png',
+  renderContent: () => ReactNode,
+): Promise<Uint8Array | undefined> {
+  const surface = CanvasKit.MakeSurface(width, height);
+
+  if (!surface) {
+    console.warn('failed to create surface');
+    return Promise.resolve(undefined);
+  }
+
+  return new Promise((resolve) => {
+    const root = (
+      <ThemeProvider theme={theme}>
+        <StateProvider state={state}>{renderContent()}</StateProvider>
+      </ThemeProvider>
+    );
+
+    render(root, surface, CanvasKit, () => {
+      const image = surface.makeImageSnapshot();
+
+      const colorSpace = image.getColorSpace();
+
+      const bytes =
+        format === 'bytes'
+          ? readPixels(image)
+          : image.encodeToBytes(CanvasKit.ImageFormat.PNG, 100);
+
+      if (!bytes) {
+        resolve(undefined);
+        return;
+      }
+
+      colorSpace.delete();
+
+      unmount(surface, () => {
+        resolve(bytes);
+
+        surface.delete();
+      });
+    });
+  });
+}

--- a/packages/noya-designsystem/src/theme/dark.ts
+++ b/packages/noya-designsystem/src/theme/dark.ts
@@ -14,6 +14,7 @@ export const colors = produce(lightTheme.colors, (colors) => {
   colors.listView.raisedBackground = 'rgba(255,255,255,0.1)';
   colors.slider.background = '#BBB';
   colors.mask = 'rgb(102,187,106)';
+  colors.transparentChecker = 'rgba(255,255,255,0.3)';
 });
 export const textStyles = lightTheme.textStyles;
 export const fonts = lightTheme.fonts;

--- a/packages/noya-designsystem/src/theme/light.ts
+++ b/packages/noya-designsystem/src/theme/light.ts
@@ -17,6 +17,7 @@ export const colors = {
   inputBackground: 'rgb(240, 240, 242)',
   codeBackground: 'rgb(250, 250, 250)',
   selectedBackground: 'rgb(242, 245, 250)',
+  transparentChecker: 'rgba(255,255,255,0.8)',
   banner: {
     top: 'rgb(222, 229, 255)',
     // bottom: 'rgb(238, 235, 255)',

--- a/packages/noya-renderer/src/components/LayerPreview.tsx
+++ b/packages/noya-renderer/src/components/LayerPreview.tsx
@@ -1,0 +1,58 @@
+import {
+  AffineTransform,
+  createBounds,
+  resizeIfLarger,
+  Size,
+} from 'noya-geometry';
+import { Group } from 'noya-react-canvaskit';
+import { SketchGroup, SketchLayer } from 'noya-renderer';
+import { Layers, PageLayer } from 'noya-state';
+import { useMemo } from 'react';
+
+interface Props {
+  layer: PageLayer;
+  size: Size;
+  padding?: number;
+}
+
+export default function LayerPreview({ layer, size, padding = 0 }: Props) {
+  const transform = useMemo(() => {
+    const bounds = createBounds(layer.frame);
+
+    const paddedSize = {
+      width: size.width - padding * 2,
+      height: size.height - padding * 2,
+    };
+
+    const layerSize = { width: layer.frame.width, height: layer.frame.height };
+
+    const scaledRect = resizeIfLarger(layerSize, paddedSize);
+
+    // Scale down to fit, if needed
+    const scale = Math.min(
+      1,
+      Math.max(
+        scaledRect.width / layerSize.width,
+        scaledRect.height / layerSize.height,
+      ),
+    );
+
+    return AffineTransform.multiply(
+      // Translate to the center of the size
+      AffineTransform.translation(size.width / 2, size.height / 2),
+      AffineTransform.scale(scale),
+      // Translate to (0,0) before scaling, since scale is applied at the origin
+      AffineTransform.translation(-bounds.midX, -bounds.midY),
+    );
+  }, [layer.frame, size.width, size.height, padding]);
+
+  return (
+    <Group transform={transform}>
+      {Layers.isSymbolMasterOrArtboard(layer) ? (
+        <SketchGroup layer={layer} />
+      ) : (
+        <SketchLayer layer={layer} />
+      )}
+    </Group>
+  );
+}

--- a/packages/noya-renderer/src/components/LayerPreview.tsx
+++ b/packages/noya-renderer/src/components/LayerPreview.tsx
@@ -11,10 +11,11 @@ import {
   Rect as RCKRect,
   useReactCanvasKit,
 } from 'noya-react-canvaskit';
-import { Primitives, SketchGroup, SketchLayer } from 'noya-renderer';
+import { Primitives, SketchLayer } from 'noya-renderer';
 import { Layers, PageLayer } from 'noya-state';
 import { useMemo } from 'react';
 import useCheckeredFill from '../hooks/useCheckeredFill';
+import { SketchArtboardContent } from './layers/SketchArtboard';
 
 function CheckeredRect({ rect }: { rect: Rect }) {
   const paint = useCheckeredFill();
@@ -73,7 +74,12 @@ export default function LayerPreview({
       {showCheckeredBackground && <CheckeredRect rect={scaledRect} />}
       <Group transform={transform}>
         {Layers.isSymbolMasterOrArtboard(layer) ? (
-          <SketchGroup layer={layer} />
+          <SketchArtboardContent
+            layer={layer}
+            showBackground={
+              layer.hasBackgroundColor && layer.includeBackgroundColorInExport
+            }
+          />
         ) : (
           <SketchLayer layer={layer} />
         )}

--- a/packages/noya-renderer/src/components/LayerPreview.tsx
+++ b/packages/noya-renderer/src/components/LayerPreview.tsx
@@ -1,20 +1,34 @@
 import {
   AffineTransform,
   createBounds,
+  Rect,
   resize,
   resizeIfLarger,
   Size,
 } from 'noya-geometry';
-import { Group } from 'noya-react-canvaskit';
-import { SketchGroup, SketchLayer } from 'noya-renderer';
+import {
+  Group,
+  Rect as RCKRect,
+  useReactCanvasKit,
+} from 'noya-react-canvaskit';
+import { Primitives, SketchGroup, SketchLayer } from 'noya-renderer';
 import { Layers, PageLayer } from 'noya-state';
 import { useMemo } from 'react';
+import useCheckeredFill from '../hooks/useCheckeredFill';
+
+function CheckeredRect({ rect }: { rect: Rect }) {
+  const paint = useCheckeredFill();
+  const { CanvasKit } = useReactCanvasKit();
+
+  return <RCKRect paint={paint} rect={Primitives.rect(CanvasKit, rect)} />;
+}
 
 interface Props {
   layer: PageLayer;
   size: Size;
   padding?: number;
   scalingMode?: 'upOrDown' | 'down';
+  showCheckeredBackground?: boolean;
 }
 
 export default function LayerPreview({
@@ -22,28 +36,29 @@ export default function LayerPreview({
   size,
   padding = 0,
   scalingMode = 'upOrDown',
+  showCheckeredBackground = false,
 }: Props) {
+  const bounds = createBounds(layer.frame);
+
+  const paddedSize = {
+    width: size.width - padding * 2,
+    height: size.height - padding * 2,
+  };
+
+  const layerSize = { width: layer.frame.width, height: layer.frame.height };
+
+  const scaledRect =
+    scalingMode === 'down'
+      ? resizeIfLarger(layerSize, paddedSize)
+      : resize(layerSize, paddedSize);
+
+  // Scale the largest side to fit, if needed
+  const scale = Math.max(
+    scaledRect.width / layerSize.width,
+    scaledRect.height / layerSize.height,
+  );
+
   const transform = useMemo(() => {
-    const bounds = createBounds(layer.frame);
-
-    const paddedSize = {
-      width: size.width - padding * 2,
-      height: size.height - padding * 2,
-    };
-
-    const layerSize = { width: layer.frame.width, height: layer.frame.height };
-
-    const scaledRect =
-      scalingMode === 'down'
-        ? resizeIfLarger(layerSize, paddedSize)
-        : resize(layerSize, paddedSize);
-
-    // Scale the largest side to fit, if needed
-    const scale = Math.max(
-      scaledRect.width / layerSize.width,
-      scaledRect.height / layerSize.height,
-    );
-
     return AffineTransform.multiply(
       // Translate to the center of the size
       AffineTransform.translation(size.width / 2, size.height / 2),
@@ -51,15 +66,18 @@ export default function LayerPreview({
       // Translate to (0,0) before scaling, since scale is applied at the origin
       AffineTransform.translation(-bounds.midX, -bounds.midY),
     );
-  }, [layer.frame, size.width, size.height, padding, scalingMode]);
+  }, [size.width, size.height, scale, bounds.midX, bounds.midY]);
 
   return (
-    <Group transform={transform}>
-      {Layers.isSymbolMasterOrArtboard(layer) ? (
-        <SketchGroup layer={layer} />
-      ) : (
-        <SketchLayer layer={layer} />
-      )}
-    </Group>
+    <>
+      {showCheckeredBackground && <CheckeredRect rect={scaledRect} />}
+      <Group transform={transform}>
+        {Layers.isSymbolMasterOrArtboard(layer) ? (
+          <SketchGroup layer={layer} />
+        ) : (
+          <SketchLayer layer={layer} />
+        )}
+      </Group>
+    </>
   );
 }

--- a/packages/noya-renderer/src/hooks/useCheckeredFill.ts
+++ b/packages/noya-renderer/src/hooks/useCheckeredFill.ts
@@ -1,0 +1,54 @@
+import { useDeletable, useReactCanvasKit } from 'noya-react-canvaskit';
+import { useMemo } from 'react';
+import { useTheme } from 'styled-components';
+
+// A simple, unoptimized decoder for small images
+function decodeBase64(string: string) {
+  return new Uint8Array(
+    atob(string)
+      .split('')
+      .map((char) => char.charCodeAt(0)),
+  );
+}
+
+const CHECKERED_BACKGROUND = `iVBORw0KGgoAAAANSUhEUgAAABgAAAAYAQMAAADaua+7AAAABlBMVEUAAAAAAAClZ7nPAAAAAXRSTlMAQObYZgAAABNJREFUCNdjYOD/TxL+/4GBFAwAvMsj3bQ3H74AAAAASUVORK5CYII=`;
+const CHECKERED_BACKGROUND_BYTES = decodeBase64(CHECKERED_BACKGROUND);
+
+export default function useCheckeredFill() {
+  const { CanvasKit } = useReactCanvasKit();
+  const { transparentChecker } = useTheme().colors;
+
+  const paint = useMemo(() => {
+    const paint = new CanvasKit.Paint();
+    const image = CanvasKit.MakeImageFromEncoded(CHECKERED_BACKGROUND_BYTES);
+
+    if (!image) return paint;
+
+    const imageShader = image.makeShaderCubic(
+      CanvasKit.TileMode.Repeat,
+      CanvasKit.TileMode.Repeat,
+      0,
+      0,
+      CanvasKit.Matrix.scaled(0.5, 0.5),
+    );
+
+    const colorShader = CanvasKit.Shader.MakeColor(
+      CanvasKit.parseColorString(transparentChecker),
+      CanvasKit.ColorSpace.SRGB,
+    );
+
+    paint.setShader(
+      CanvasKit.Shader.MakeBlend(
+        CanvasKit.BlendMode.DstATop,
+        colorShader,
+        imageShader,
+      ),
+    );
+
+    return paint;
+  }, [CanvasKit, transparentChecker]);
+
+  useDeletable(paint);
+
+  return paint;
+}

--- a/packages/noya-renderer/src/index.ts
+++ b/packages/noya-renderer/src/index.ts
@@ -7,6 +7,7 @@ export { default as SketchFileRenderer } from './components/SketchFileRenderer';
 export { default as SketchLayer } from './components/layers/SketchLayer';
 export { default as SketchArtboard } from './components/layers/SketchArtboard';
 export { default as SketchGroup } from './components/layers/SketchGroup';
+export { default as LayerPreview } from './components/LayerPreview';
 
 export type { Context };
 export { uuid, Primitives };

--- a/packages/noya-state/src/exportOptions.ts
+++ b/packages/noya-state/src/exportOptions.ts
@@ -11,12 +11,21 @@ export type ExportSize = {
   visibleScaleType: Sketch.VisibleScaleType;
 };
 
-export function parseScale(scaleText: string): ExportSize | undefined {
-  const size = isNaN(parseFloat(scaleText))
-    ? parseFloat(scaleText.slice(0, -1))
-    : parseFloat(scaleText);
+function parseFloatWithSuffix(value: string): number | undefined {
+  let parsed = parseFloat(value);
 
-  if (isNaN(size) || size <= 0) return undefined;
+  if (!isNaN(parsed)) return parsed;
+
+  // Remove the single-character suffix
+  parsed = parseFloat(value.slice(0, -1));
+
+  return isNaN(parsed) ? undefined : parsed;
+}
+
+export function parseScale(scaleText: string): ExportSize | undefined {
+  const size = parseFloatWithSuffix(scaleText);
+
+  if (size === undefined || size <= 0) return undefined;
 
   const visibleScaleType =
     scaleText[scaleText.length - 1] === 'w'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2466,6 +2466,15 @@
     "@radix-ui/react-polymorphic" "0.0.6"
     "@radix-ui/react-primitive" "0.0.5"
 
+"@radix-ui/react-aspect-ratio@^0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-0.0.14.tgz#ee0bd04f544752320d6ac1a7bef19d339dc04194"
+  integrity sha512-Dc7nXb6sLPWcrzjHRWmlO/aRa0zFLIHQ+ghz01AHHwjEs9B8QE+fv7EDwE813JPwBLxKFUipBuJfhpjkYWEfGA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-polymorphic" "0.0.12"
+    "@radix-ui/react-primitive" "0.0.14"
+
 "@radix-ui/react-collection@0.0.12":
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-0.0.12.tgz#5cd09312cdec34fdbbe1d31affaba69eb768e342"
@@ -2638,6 +2647,11 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-polymorphic@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.12.tgz#bf4ae516669b68e059549538104d97322f7c876b"
+  integrity sha512-/GYNMicBnGzjD1d2fCAuzql1VeFrp8mqM3xfzT1kxhnV85TKdURO45jBfMgqo17XNXoNhWIAProUsCO4qFAAIg==
+
 "@radix-ui/react-polymorphic@0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.5.tgz#7742695d5a47c732b3c5f627dfcd037c03f07f5b"
@@ -2741,6 +2755,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-polymorphic" "0.0.11"
+
+"@radix-ui/react-primitive@0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-0.0.14.tgz#752a967cb05d4c5643634fe20274e7dc905d1cce"
+  integrity sha512-FYOWGCrxFpLdB534aWTwMK4Pjg8cxFb+745qWhPfI+cYi+aYUddJQD3ilRHHXxCBD72ve7/PufqeB7Y/QlKqgg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-polymorphic" "0.0.12"
 
 "@radix-ui/react-primitive@0.0.5":
   version "0.0.5"


### PR DESCRIPTION
We now show an export preview image for every kind of layer. We also have a basic way to export a layer as a single PNG.

TODO:
- Exporting using the defined export formats
- Fix an issue where the size of the inspector jitters due to the preview's automatic resizing (fix with custom scroll area)

![Screen Shot 2021-06-25 at 1 24 26 PM](https://user-images.githubusercontent.com/1198882/123481722-fe2d1c00-d5b8-11eb-87a8-214d1da1d2a7.png)
![Screen Shot 2021-06-25 at 1 24 48 PM](https://user-images.githubusercontent.com/1198882/123481701-f79ea480-d5b8-11eb-96d5-dd93afcd2dc5.png)
![Screen Shot 2021-06-25 at 1 24 07 PM](https://user-images.githubusercontent.com/1198882/123481692-f2d9f080-d5b8-11eb-8b0e-88234323cb2d.png)
