### PR TITLE
Refactor fill picker

### DIFF
--- a/packages/app/src/components/inspector/BorderRow.tsx
+++ b/packages/app/src/components/inspector/BorderRow.tsx
@@ -1,18 +1,22 @@
 import Sketch from '@sketch-hq/sketch-file-format-ts';
 import {
-  InputField,
   Label,
   LabeledElementView,
   RadioGroup,
   Spacer,
 } from 'noya-designsystem';
 import { memo, ReactNode, useCallback } from 'react';
-import styled from 'styled-components';
+import { SetNumberMode } from 'noya-state';
 import BorderCenterIcon from '../icons/BorderCenterIcon';
 import BorderInsideIcon from '../icons/BorderInsideIcon';
 import BorderOutsideIcon from '../icons/BorderOutsideIcon';
-import FillInputFieldWithPicker from './FillInputFieldWithPicker';
+import * as InspectorPrimitives from '../inspector/InspectorPrimitives';
+import DimensionInput from './DimensionInput';
 import { DimensionValue } from './DimensionsInspector';
+import FillInputFieldWithPicker, {
+  ColorFillProps,
+  GradientFillProps,
+} from './FillInputFieldWithPicker';
 
 function toPositionString(position: Sketch.BorderPosition) {
   switch (position) {
@@ -38,49 +42,30 @@ function toPositionEnum(position: string): Sketch.BorderPosition {
   }
 }
 
-const Row = styled.div(({ theme }) => ({
-  flex: '1',
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-}));
-
 interface Props {
   id: string;
-  value: Sketch.Color | Sketch.Gradient;
+  prefix?: ReactNode;
+  fillType?: Sketch.FillType;
   width: DimensionValue;
   position: Sketch.BorderPosition;
-  onChangeColor: (color: Sketch.Color) => void;
+  onSetWidth: (amount: number, mode: SetNumberMode) => void;
   onChangePosition: (value: Sketch.BorderPosition) => void;
-  onChangeWidth: (amount: number) => void;
   onChangeFillType: (type: Sketch.FillType) => void;
-  onChangeGradientColor: (color: Sketch.Color, index: number) => void;
-  onChangeGradientPosition: (index: number, position: number) => void;
-  onAddGradientStop: (color: Sketch.Color, position: number) => void;
-  onDeleteGradientStop: (index: number) => void;
-  onChangeGradient: (gradient: Sketch.Gradient) => void;
-  onChangeGradientType: (type: Sketch.GradientType) => void;
-  onNudgeWidth: (amount: number) => void;
-  prefix?: ReactNode;
+  colorProps: ColorFillProps;
+  gradientProps: GradientFillProps;
 }
 
 export default memo(function BorderRow({
   id,
-  value,
+  prefix,
+  fillType,
   width,
   position,
-  onChangeColor,
-  onChangeWidth,
+  onSetWidth,
   onChangePosition,
-  onNudgeWidth,
   onChangeFillType,
-  onChangeGradient,
-  onChangeGradientColor,
-  onChangeGradientPosition,
-  onAddGradientStop,
-  onDeleteGradientStop,
-  onChangeGradientType,
-  prefix,
+  colorProps,
+  gradientProps,
 }: Props) {
   const colorInputId = `${id}-color`;
   const borderPositionId = `${id}-hex`;
@@ -102,13 +87,6 @@ export default memo(function BorderRow({
     [colorInputId, borderPositionId, widthInputId],
   );
 
-  const handleSubmitWidth = useCallback(
-    (value: number) => {
-      onChangeWidth(value);
-    },
-    [onChangeWidth],
-  );
-
   const handleChangePosition = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       onChangePosition(toPositionEnum(event.target.value));
@@ -117,21 +95,16 @@ export default memo(function BorderRow({
   );
 
   return (
-    <Row>
+    <InspectorPrimitives.Row>
       <LabeledElementView renderLabel={renderLabel}>
         {prefix}
         {prefix && <Spacer.Horizontal size={8} />}
         <FillInputFieldWithPicker
           id={colorInputId}
-          value={value}
-          onChange={onChangeColor}
+          fillType={fillType}
           onChangeType={onChangeFillType}
-          onChangeGradient={onChangeGradient}
-          onChangeGradientColor={onChangeGradientColor}
-          onChangeGradientPosition={onChangeGradientPosition}
-          onAddGradientStop={onAddGradientStop}
-          onChangeGradientType={onChangeGradientType}
-          onDeleteGradientStop={onDeleteGradientStop}
+          colorProps={colorProps}
+          gradientProps={gradientProps}
         />
         <Spacer.Horizontal size={8} />
         <RadioGroup.Root
@@ -150,15 +123,13 @@ export default memo(function BorderRow({
           </RadioGroup.Item>
         </RadioGroup.Root>
         <Spacer.Horizontal size={8} />
-        <InputField.Root id={widthInputId} size={50}>
-          <InputField.NumberInput
-            value={width}
-            onNudge={onNudgeWidth}
-            onSubmit={handleSubmitWidth}
-            placeholder={width === undefined ? 'multi' : ''}
-          />
-        </InputField.Root>
+        <DimensionInput
+          id={widthInputId}
+          size={50}
+          value={width}
+          onSetValue={onSetWidth}
+        />
       </LabeledElementView>
-    </Row>
+    </InspectorPrimitives.Row>
   );
 });

--- a/packages/app/src/components/inspector/ColorInspector.tsx
+++ b/packages/app/src/components/inspector/ColorInspector.tsx
@@ -7,24 +7,11 @@ import {
   sketchColorToHex,
   Spacer,
 } from 'noya-designsystem';
+import { SetNumberMode } from 'noya-state';
 import { clamp } from 'noya-utils';
 import { memo, useCallback } from 'react';
-import styled from 'styled-components';
-import { SetNumberMode } from 'noya-state';
 import DimensionInput from './DimensionInput';
-
-const Row = styled.div(({ theme }) => ({
-  flex: '1',
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-}));
-
-const Column = styled.div(({ theme }) => ({
-  flex: '1',
-  display: 'flex',
-  flexDirection: 'column',
-}));
+import * as InspectorPrimitives from './InspectorPrimitives';
 
 const DEFAULT_SKETCH_COLOR: Sketch.Color = {
   _class: 'color',
@@ -92,30 +79,32 @@ export default memo(function ColorInspector({
   );
 
   return (
-    <Column>
-      <ColorPicker value={displayColor} onChange={onChangeColor} />
-      <Spacer.Vertical size={10} />
-      <Row id={id}>
-        <LabeledElementView renderLabel={renderLabel}>
-          <Spacer.Vertical size={8} />
-          <InputField.Root id={hexInputId} labelPosition="start">
-            <InputField.Input
-              value={color ? sketchColorToHex(displayColor).slice(1) : ''}
-              placeholder={color ? '' : 'multiple'}
-              onSubmit={useCallback(() => {}, [])}
+    <InspectorPrimitives.Section>
+      <InspectorPrimitives.Column>
+        <ColorPicker value={displayColor} onChange={onChangeColor} />
+        <Spacer.Vertical size={10} />
+        <InspectorPrimitives.Row id={id}>
+          <LabeledElementView renderLabel={renderLabel}>
+            <Spacer.Vertical size={8} />
+            <InputField.Root id={hexInputId} labelPosition="start">
+              <InputField.Input
+                value={color ? sketchColorToHex(displayColor).slice(1) : ''}
+                placeholder={color ? '' : 'multiple'}
+                onSubmit={useCallback(() => {}, [])}
+              />
+              <InputField.Label>#</InputField.Label>
+            </InputField.Root>
+            <Spacer.Horizontal size={8} />
+            <DimensionInput
+              id={opacityInputId}
+              size={50}
+              label="%"
+              value={color ? Math.round(color.alpha * 100) : undefined}
+              onSetValue={handleSetOpacity}
             />
-            <InputField.Label>#</InputField.Label>
-          </InputField.Root>
-          <Spacer.Horizontal size={8} />
-          <DimensionInput
-            id={opacityInputId}
-            size={50}
-            label="%"
-            value={color ? Math.round(color.alpha * 100) : undefined}
-            onSetValue={handleSetOpacity}
-          />
-        </LabeledElementView>
-      </Row>
-    </Column>
+          </LabeledElementView>
+        </InspectorPrimitives.Row>
+      </InspectorPrimitives.Column>
+    </InspectorPrimitives.Section>
   );
 });

--- a/packages/app/src/components/inspector/FillRow.tsx
+++ b/packages/app/src/components/inspector/FillRow.tsx
@@ -17,7 +17,7 @@ import FillInputFieldWithPicker, {
   GradientFillProps,
   PatternFillProps,
 } from './FillInputFieldWithPicker';
-import { patternFillTypeOptions, PatternFillTypes } from './PatternInspector';
+import { PATTERN_FILL_TYPE_OPTIONS, PatternFillType } from './PatternInspector';
 
 const GRADIENT_TYPE_OPTIONS = [
   Sketch.GradientType.Linear.toString(),
@@ -52,17 +52,28 @@ export default memo(function FillRow({
   gradientProps,
   patternProps,
 }: Props) {
-  const colorInputId = `${id}-color`;
+  const fillInputId = `${id}-color`;
   const hexInputId = `${id}-hex`;
   const opacityInputId = `${id}-opacity`;
   const gradientTypeId = `${id}-gradient-type`;
   const patternSizeId = `${id}-pattern-type`;
 
+  const fillLabel = useMemo(() => {
+    switch (fillType) {
+      case Sketch.FillType.Color:
+        return 'Color';
+      case Sketch.FillType.Gradient:
+        return 'Gradient';
+      case Sketch.FillType.Pattern:
+        return 'Image';
+    }
+  }, [fillType]);
+
   const renderLabel = useCallback(
     ({ id }) => {
       switch (id) {
-        case colorInputId:
-          return <Label.Label>Color</Label.Label>;
+        case fillInputId:
+          return <Label.Label>{fillLabel}</Label.Label>;
         case hexInputId:
           return <Label.Label>Hex</Label.Label>;
         case opacityInputId:
@@ -75,7 +86,14 @@ export default memo(function FillRow({
           return null;
       }
     },
-    [colorInputId, hexInputId, opacityInputId, gradientTypeId, patternSizeId],
+    [
+      fillInputId,
+      fillLabel,
+      hexInputId,
+      opacityInputId,
+      gradientTypeId,
+      patternSizeId,
+    ],
   );
 
   const handleSetOpacity = useCallback(
@@ -100,7 +118,7 @@ export default memo(function FillRow({
   );
 
   const handleSelectPatternSize = useCallback(
-    (value: PatternFillTypes) =>
+    (value: PatternFillType) =>
       patternProps.onChangePatternFillType(Sketch.PatternFillType[value]),
     [patternProps],
   );
@@ -139,15 +157,13 @@ export default memo(function FillRow({
       case Sketch.FillType.Gradient:
         return (
           <>
-            <InputField.Root id={gradientTypeId}>
-              <Select
-                id={`${id}-gradient-type-select`}
-                value={gradientProps.gradient.gradientType.toString()}
-                options={GRADIENT_TYPE_OPTIONS}
-                getTitle={getGradientTypeTitle}
-                onChange={handleSelectGradientType}
-              />
-            </InputField.Root>
+            <Select
+              id={gradientTypeId}
+              value={gradientProps.gradient.gradientType.toString()}
+              options={GRADIENT_TYPE_OPTIONS}
+              getTitle={getGradientTypeTitle}
+              onChange={handleSelectGradientType}
+            />
             <Spacer.Horizontal size={8} />
             <DimensionInput
               id={opacityInputId}
@@ -161,18 +177,16 @@ export default memo(function FillRow({
       case Sketch.FillType.Pattern:
         return (
           <>
-            <InputField.Root id={patternSizeId}>
-              <Select
-                id={`${id}-gradient-type-selector`}
-                value={
-                  Sketch.PatternFillType[
-                    patternProps.pattern.patternFillType
-                  ] as PatternFillTypes
-                }
-                options={patternFillTypeOptions}
-                onChange={handleSelectPatternSize}
-              />
-            </InputField.Root>
+            <Select
+              id={patternSizeId}
+              value={
+                Sketch.PatternFillType[
+                  patternProps.pattern.patternFillType
+                ] as PatternFillType
+              }
+              options={PATTERN_FILL_TYPE_OPTIONS}
+              onChange={handleSelectPatternSize}
+            />
             <Spacer.Horizontal size={8} />
             <DimensionInput
               id={opacityInputId}
@@ -196,7 +210,6 @@ export default memo(function FillRow({
     handleSetContextOpacity,
     handleSetOpacity,
     hexInputId,
-    id,
     opacityInputId,
     patternProps.pattern.patternFillType,
     patternSizeId,
@@ -208,7 +221,7 @@ export default memo(function FillRow({
         {prefix}
         {prefix && <Spacer.Horizontal size={8} />}
         <FillInputFieldWithPicker
-          id={colorInputId}
+          id={fillInputId}
           fillType={fillType}
           onChangeType={onChangeFillType}
           colorProps={colorProps}

--- a/packages/app/src/components/inspector/GradientInspector.tsx
+++ b/packages/app/src/components/inspector/GradientInspector.tsx
@@ -9,20 +9,7 @@ import {
 } from 'noya-designsystem';
 import { clamp } from 'noya-utils';
 import { memo, useCallback, useMemo, useState } from 'react';
-import styled from 'styled-components';
-
-const Row = styled.div(({ theme }) => ({
-  flex: '1',
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-}));
-
-const Column = styled.div(({ theme }) => ({
-  flex: '1',
-  display: 'flex',
-  flexDirection: 'column',
-}));
+import * as InspectorPrimitives from './InspectorPrimitives';
 
 interface Props {
   id: string;
@@ -141,42 +128,44 @@ export default memo(function GradientInspector({
   }, [gradient, clampedSelectedStopIndex, onDeleteStop, setSelectedStopIndex]);
 
   return (
-    <Column>
-      <GradientPicker
-        value={gradient}
-        selectedStop={clampedSelectedStopIndex}
-        onChangeColor={handleChangeColor}
-        onChangePosition={handleChangePosition}
-        onAdd={handleAddStop}
-        onSelectStop={useCallback(
-          (index: number) => setSelectedStopIndex(index),
-          [setSelectedStopIndex],
-        )}
-        onDelete={handleDeleteStop}
-      />
-      <Spacer.Vertical size={10} />
-      <Row id={id}>
-        <LabeledElementView renderLabel={renderLabel}>
-          <Spacer.Vertical size={8} />
-          <InputField.Root id={hexInputId} labelPosition="start">
-            <InputField.Input
-              value={hexValue ?? ''}
-              placeholder={hexValue ? '' : 'Multiple'}
-              onSubmit={useCallback(() => {}, [])}
-            />
-            <InputField.Label>#</InputField.Label>
-          </InputField.Root>
-          <Spacer.Horizontal size={8} />
-          <InputField.Root id={opacityInputId} size={50}>
-            <InputField.NumberInput
-              value={Math.round(selectedcolor.alpha * 100)}
-              onSubmit={handleSubmitOpacity}
-              onNudge={handleNudgeOpacity}
-            />
-            <InputField.Label>%</InputField.Label>
-          </InputField.Root>
-        </LabeledElementView>
-      </Row>
-    </Column>
+    <InspectorPrimitives.Section>
+      <InspectorPrimitives.Column>
+        <GradientPicker
+          value={gradient}
+          selectedStop={clampedSelectedStopIndex}
+          onChangeColor={handleChangeColor}
+          onChangePosition={handleChangePosition}
+          onAdd={handleAddStop}
+          onSelectStop={useCallback(
+            (index: number) => setSelectedStopIndex(index),
+            [setSelectedStopIndex],
+          )}
+          onDelete={handleDeleteStop}
+        />
+        <Spacer.Vertical size={10} />
+        <InspectorPrimitives.Row id={id}>
+          <LabeledElementView renderLabel={renderLabel}>
+            <Spacer.Vertical size={8} />
+            <InputField.Root id={hexInputId} labelPosition="start">
+              <InputField.Input
+                value={hexValue ?? ''}
+                placeholder={hexValue ? '' : 'Multiple'}
+                onSubmit={useCallback(() => {}, [])}
+              />
+              <InputField.Label>#</InputField.Label>
+            </InputField.Root>
+            <Spacer.Horizontal size={8} />
+            <InputField.Root id={opacityInputId} size={50}>
+              <InputField.NumberInput
+                value={Math.round(selectedcolor.alpha * 100)}
+                onSubmit={handleSubmitOpacity}
+                onNudge={handleNudgeOpacity}
+              />
+              <InputField.Label>%</InputField.Label>
+            </InputField.Root>
+          </LabeledElementView>
+        </InspectorPrimitives.Row>
+      </InspectorPrimitives.Column>
+    </InspectorPrimitives.Section>
   );
 });

--- a/packages/app/src/components/inspector/PatternInspector.tsx
+++ b/packages/app/src/components/inspector/PatternInspector.tsx
@@ -204,26 +204,28 @@ export default memo(function PatternInspector({
             onChange={changeFillType}
           />
         </InspectorPrimitives.LabeledRow>
-        <Spacer.Vertical size={10} />
         {isTile && (
-          <InspectorPrimitives.LabeledSliderRow label={'Scale'}>
-            <Slider
-              id={`${id}-slider`}
-              value={scale}
-              onValueChange={onSubmitTileScale}
-              min={10}
-              max={200}
-            />
-            <Spacer.Horizontal size={10} />
-            <InputField.Root size={50}>
-              <InputField.NumberInput
+          <>
+            <Spacer.Vertical size={10} />
+            <InspectorPrimitives.LabeledSliderRow label={'Scale'}>
+              <Slider
+                id={`${id}-slider`}
                 value={scale}
-                onSubmit={onSubmitTileScale}
-                onNudge={onNudgeTileScale}
+                onValueChange={onSubmitTileScale}
+                min={10}
+                max={200}
               />
-              <InputField.Label>{'%'}</InputField.Label>
-            </InputField.Root>
-          </InspectorPrimitives.LabeledSliderRow>
+              <Spacer.Horizontal size={10} />
+              <InputField.Root size={50}>
+                <InputField.NumberInput
+                  value={scale}
+                  onSubmit={onSubmitTileScale}
+                  onNudge={onNudgeTileScale}
+                />
+                <InputField.Label>{'%'}</InputField.Label>
+              </InputField.Root>
+            </InspectorPrimitives.LabeledSliderRow>
+          </>
         )}
       </InspectorPrimitives.Column>
     </InspectorPrimitives.Section>

--- a/packages/app/src/components/inspector/PatternInspector.tsx
+++ b/packages/app/src/components/inspector/PatternInspector.tsx
@@ -177,53 +177,55 @@ export default memo(function PatternInspector({
   const scale = Math.round(pattern.patternTileScale * 100);
 
   return (
-    <InspectorPrimitives.Column>
-      <Container
-        {...dropTargetProps}
-        {...hoverProps}
-        isActive={isDropTargetActive}
-        background={background}
-        backgroundSize={backgroundSize}
-        repeat={isTile}
-      >
-        <UploadButton
-          show={!isDropTargetActive && isHovering}
-          onClick={openFile}
+    <InspectorPrimitives.Section>
+      <InspectorPrimitives.Column>
+        <Container
+          {...dropTargetProps}
+          {...hoverProps}
+          isActive={isDropTargetActive}
+          background={background}
+          backgroundSize={backgroundSize}
+          repeat={isTile}
         >
-          Upload Image
-        </UploadButton>
-      </Container>
-      <Spacer.Vertical size={10} />
-      <InspectorPrimitives.LabeledRow label={'Size'}>
+          <UploadButton
+            show={!isDropTargetActive && isHovering}
+            onClick={openFile}
+          >
+            Upload Image
+          </UploadButton>
+        </Container>
         <Spacer.Vertical size={10} />
-        <Select
-          id={`${id}-pattern-options`}
-          value={Sketch.PatternFillType[patternType] as PatternFillTypes}
-          options={patternFillTypeOptions}
-          onChange={changeFillType}
-        />
-      </InspectorPrimitives.LabeledRow>
-      <Spacer.Vertical size={10} />
-      {isTile && (
-        <InspectorPrimitives.LabeledSliderRow label={'Scale'}>
-          <Slider
-            id={`${id}-slider`}
-            value={scale}
-            onValueChange={onSubmitTileScale}
-            min={10}
-            max={200}
+        <InspectorPrimitives.LabeledRow label={'Size'}>
+          <Spacer.Vertical size={10} />
+          <Select
+            id={`${id}-pattern-options`}
+            value={Sketch.PatternFillType[patternType] as PatternFillTypes}
+            options={patternFillTypeOptions}
+            onChange={changeFillType}
           />
-          <Spacer.Horizontal size={10} />
-          <InputField.Root size={50}>
-            <InputField.NumberInput
+        </InspectorPrimitives.LabeledRow>
+        <Spacer.Vertical size={10} />
+        {isTile && (
+          <InspectorPrimitives.LabeledSliderRow label={'Scale'}>
+            <Slider
+              id={`${id}-slider`}
               value={scale}
-              onSubmit={onSubmitTileScale}
-              onNudge={onNudgeTileScale}
+              onValueChange={onSubmitTileScale}
+              min={10}
+              max={200}
             />
-            <InputField.Label>{'%'}</InputField.Label>
-          </InputField.Root>
-        </InspectorPrimitives.LabeledSliderRow>
-      )}
-    </InspectorPrimitives.Column>
+            <Spacer.Horizontal size={10} />
+            <InputField.Root size={50}>
+              <InputField.NumberInput
+                value={scale}
+                onSubmit={onSubmitTileScale}
+                onNudge={onNudgeTileScale}
+              />
+              <InputField.Label>{'%'}</InputField.Label>
+            </InputField.Root>
+          </InspectorPrimitives.LabeledSliderRow>
+        )}
+      </InspectorPrimitives.Column>
+    </InspectorPrimitives.Section>
   );
 });

--- a/packages/app/src/components/inspector/PatternInspector.tsx
+++ b/packages/app/src/components/inspector/PatternInspector.tsx
@@ -66,8 +66,9 @@ interface Props {
   createImage: (image: ArrayBuffer, _ref: string) => void;
 }
 
-export type PatternFillTypes = 'Stretch' | 'Fill' | 'Fit' | 'Tile';
-export const patternFillTypeOptions: PatternFillTypes[] = [
+export type PatternFillType = 'Stretch' | 'Fill' | 'Fit' | 'Tile';
+
+export const PATTERN_FILL_TYPE_OPTIONS: PatternFillType[] = [
   'Tile',
   'Fill',
   'Stretch',
@@ -92,7 +93,7 @@ export default memo(function PatternInspector({
   const isTile = patternType === Sketch.PatternFillType.Tile;
 
   const changeFillType = useCallback(
-    (value: PatternFillTypes) => {
+    (value: PatternFillType) => {
       onChangeFillType(Sketch.PatternFillType[value]);
     },
     [onChangeFillType],
@@ -199,8 +200,8 @@ export default memo(function PatternInspector({
           <Spacer.Vertical size={10} />
           <Select
             id={`${id}-pattern-options`}
-            value={Sketch.PatternFillType[patternType] as PatternFillTypes}
-            options={patternFillTypeOptions}
+            value={Sketch.PatternFillType[patternType] as PatternFillType}
+            options={PATTERN_FILL_TYPE_OPTIONS}
             onChange={changeFillType}
           />
         </InspectorPrimitives.LabeledRow>

--- a/packages/app/src/components/inspector/PatternInspector.tsx
+++ b/packages/app/src/components/inspector/PatternInspector.tsx
@@ -18,12 +18,6 @@ import { FileMap } from 'noya-sketch-file';
 import { useHover } from 'noya-designsystem/src/hooks/useHover';
 import { useFileDropTarget } from '../../hooks/useFileDropTarget';
 
-const Column = styled.div(({ theme }) => ({
-  flex: '1',
-  display: 'flex',
-  flexDirection: 'column',
-}));
-
 const Container = styled.div<{
   background: string;
   backgroundSize: string;
@@ -47,30 +41,28 @@ const Container = styled.div<{
   justifyContent: 'center',
 }));
 
-const UploadButton = styled.button<{ show: boolean }>(
-  ({ theme, show = false }) => ({
-    color: 'white',
-    position: 'absolute',
-    background: 'rgba(0, 0, 0, 0.75)',
-    cursor: 'pointer',
-    userSelect: 'auto',
-    alignSelf: 'center',
-    height: '30px',
-    width: '105px',
-    borderRadius: '24px',
-    border: 'none',
-    display: show ? 'block' : 'none',
-    zIndex: 1,
-  }),
-);
+const UploadButton = styled.button<{ show: boolean }>(({ show = false }) => ({
+  color: 'white',
+  position: 'absolute',
+  background: 'rgba(0, 0, 0, 0.75)',
+  cursor: 'pointer',
+  userSelect: 'auto',
+  alignSelf: 'center',
+  height: '30px',
+  width: '105px',
+  borderRadius: '24px',
+  border: 'none',
+  display: show ? 'block' : 'none',
+  zIndex: 1,
+}));
 
 interface Props {
   id: string;
   images: FileMap;
   pattern: SketchPattern;
-  onChangeImage?: (image: Sketch.FileRef | Sketch.DataRef) => void;
-  onChangeFillType?: (amount: Sketch.PatternFillType) => void;
-  onChangeTileScale?: (amount: number) => void;
+  onChangeImage: (image: Sketch.FileRef | Sketch.DataRef) => void;
+  onChangeFillType: (amount: Sketch.PatternFillType) => void;
+  onChangeTileScale: (amount: number) => void;
   createImage: (image: ArrayBuffer, _ref: string) => void;
 }
 
@@ -101,21 +93,21 @@ export default memo(function PatternInspector({
 
   const changeFillType = useCallback(
     (value: PatternFillTypes) => {
-      onChangeFillType?.(Sketch.PatternFillType[value]);
+      onChangeFillType(Sketch.PatternFillType[value]);
     },
     [onChangeFillType],
   );
 
   const onSubmitTileScale = useCallback(
     (value: number) => {
-      onChangeTileScale?.(value / 100);
+      onChangeTileScale(value / 100);
     },
     [onChangeTileScale],
   );
 
   const onNudgeTileScale = useCallback(
     (value: number) => {
-      onChangeTileScale?.(value / 100);
+      onChangeTileScale(value / 100);
     },
     [onChangeTileScale],
   );
@@ -145,7 +137,7 @@ export default memo(function PatternInspector({
       const _ref = `images/${uuid()}.${extension}`;
 
       createImage(data, _ref);
-      onChangeImage?.({
+      onChangeImage({
         _class: 'MSJSONFileReference',
         _ref: _ref,
         _ref_class: 'MSImageData',
@@ -185,7 +177,7 @@ export default memo(function PatternInspector({
   const scale = Math.round(pattern.patternTileScale * 100);
 
   return (
-    <Column>
+    <InspectorPrimitives.Column>
       <Container
         {...dropTargetProps}
         {...hoverProps}
@@ -232,6 +224,6 @@ export default memo(function PatternInspector({
           </InputField.Root>
         </InspectorPrimitives.LabeledSliderRow>
       )}
-    </Column>
+    </InspectorPrimitives.Column>
   );
 });

--- a/packages/app/src/components/inspector/PickerAssetGrid.tsx
+++ b/packages/app/src/components/inspector/PickerAssetGrid.tsx
@@ -3,12 +3,6 @@ import { RadioGroup } from 'noya-designsystem';
 import styled from 'styled-components';
 import { memo, useCallback } from 'react';
 
-export const PaddedSection = styled.section({
-  padding: '8px 10px',
-  display: 'flex',
-  flexDirection: 'column',
-});
-
 export const Square = styled.div<{ background: string; selected?: boolean }>(
   ({ theme, background, selected = false }) => ({
     height: '25px',
@@ -30,13 +24,6 @@ export const GridSmall = styled.div({
   gap: '5px',
 });
 
-export const Row = styled.div(({ theme }) => ({
-  flex: '1',
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'stretch',
-}));
-
 export const RadioGroupContainer = styled.div({
   flex: '0 0 50px',
   display: 'flex',
@@ -45,7 +32,7 @@ export const RadioGroupContainer = styled.div({
 
 export type LayoutType = 'list' | 'grid';
 
-export const LayoutPicker = memo(
+export const LayoutRadioGroup = memo(
   ({
     layout,
     setLayout,

--- a/packages/app/src/components/inspector/PickerGradients.tsx
+++ b/packages/app/src/components/inspector/PickerGradients.tsx
@@ -10,13 +10,12 @@ import {
   MenuItem,
 } from 'noya-designsystem';
 import { memo, useState, useCallback } from 'react';
+import * as InspectorPrimitives from '../inspector/InspectorPrimitives';
 import {
-  PaddedSection,
   GridSmall,
-  Row,
   Square,
   LayoutType,
-  LayoutPicker,
+  LayoutRadioGroup,
 } from './PickerAssetGrid';
 
 export type MenuItemType = 'rename' | 'delete';
@@ -142,14 +141,14 @@ export default memo(function PickerGradients({
 
   return (
     <>
-      <PaddedSection>
-        <Button id={'crete-theme-gradient'} onClick={onCreate}>
+      <InspectorPrimitives.Section>
+        <Button id={'create-theme-gradient'} onClick={onCreate}>
           Create Theme Gradient
         </Button>
-      </PaddedSection>
+      </InspectorPrimitives.Section>
       <Divider />
-      <PaddedSection>
-        <Row>
+      <InspectorPrimitives.Section>
+        <InspectorPrimitives.Row>
           <Select
             id="gradient-category"
             options={['Document']}
@@ -157,26 +156,31 @@ export default memo(function PickerGradients({
             onChange={() => {}}
           />
           <Spacer.Horizontal size={8} />
-          <LayoutPicker layout={gradientLayout} setLayout={setGradientLayout} />
-        </Row>
-      </PaddedSection>
-      <PaddedSection>
-        {gradientLayout === 'grid' ? (
-          <GradientsGrid
-            gradients={gradientAssets}
-            setGradientId={setGradientId}
-            handleSelectMenuItem={handleSelectMenuItem}
-            onSelectGradientAsset={onChange}
+          <LayoutRadioGroup
+            layout={gradientLayout}
+            setLayout={setGradientLayout}
           />
-        ) : (
-          <GradientsList
-            gradients={gradientAssets}
-            setGradientId={setGradientId}
-            handleSelectMenuItem={handleSelectMenuItem}
-            onSelectGradientAsset={onChange}
-          />
-        )}
-      </PaddedSection>
+        </InspectorPrimitives.Row>
+      </InspectorPrimitives.Section>
+      {gradientAssets.length > 0 && (
+        <InspectorPrimitives.Section>
+          {gradientLayout === 'grid' ? (
+            <GradientsGrid
+              gradients={gradientAssets}
+              setGradientId={setGradientId}
+              handleSelectMenuItem={handleSelectMenuItem}
+              onSelectGradientAsset={onChange}
+            />
+          ) : (
+            <GradientsList
+              gradients={gradientAssets}
+              setGradientId={setGradientId}
+              handleSelectMenuItem={handleSelectMenuItem}
+              onSelectGradientAsset={onChange}
+            />
+          )}
+        </InspectorPrimitives.Section>
+      )}
     </>
   );
 });

--- a/packages/app/src/components/inspector/PickerGradients.tsx
+++ b/packages/app/src/components/inspector/PickerGradients.tsx
@@ -104,15 +104,14 @@ const GradientsGrid = memo(function GradientsGrid({
 });
 
 interface Props {
-  gradientType?: Sketch.GradientType;
   gradientAssets: Sketch.GradientAsset[];
   onCreate: () => void;
-  onChange?: (gradient: Sketch.Gradient) => void;
+  onChange: (gradient: Sketch.Gradient) => void;
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;
 }
 
-export default memo(function ColorPickerGradients({
+export default memo(function PickerGradients({
   gradientAssets,
   onChange,
   onCreate,
@@ -140,8 +139,6 @@ export default memo(function ColorPickerGradients({
     },
     [gradientId, onRename, onDelete],
   );
-
-  if (!onChange) return null;
 
   return (
     <>

--- a/packages/app/src/components/inspector/PickerPatterns.tsx
+++ b/packages/app/src/components/inspector/PickerPatterns.tsx
@@ -15,7 +15,7 @@ interface Props {
   onChange?: (color: Sketch.FileRef | Sketch.DataRef) => void;
 }
 
-export default memo(function ColorPickerPattern({
+export default memo(function PickerPatterns({
   fileImages,
   imageAssets,
   onChange,

--- a/packages/app/src/components/inspector/PickerPatterns.tsx
+++ b/packages/app/src/components/inspector/PickerPatterns.tsx
@@ -1,18 +1,14 @@
 import type Sketch from '@sketch-hq/sketch-file-format-ts';
-import {
-  Spacer,
-  Select,
-  Divider,
-  getPatternBackground,
-} from 'noya-designsystem';
-import { memo, useMemo } from 'react';
+import { Divider, getPatternBackground, Select } from 'noya-designsystem';
 import { FileMap } from 'noya-sketch-file';
-import { PaddedSection, GridSmall, Row, Square } from './PickerAssetGrid';
+import { memo } from 'react';
+import * as InspectorPrimitives from '../inspector/InspectorPrimitives';
+import { GridSmall, Square } from './PickerAssetGrid';
 
 interface Props {
   fileImages: FileMap;
   imageAssets: (Sketch.FileRef | Sketch.DataRef)[];
-  onChange?: (color: Sketch.FileRef | Sketch.DataRef) => void;
+  onChange: (color: Sketch.FileRef | Sketch.DataRef) => void;
 }
 
 export default memo(function PickerPatterns({
@@ -20,41 +16,32 @@ export default memo(function PickerPatterns({
   imageAssets,
   onChange,
 }: Props) {
-  const elements = useMemo(
-    () =>
-      imageAssets.map((item) => {
-        const value = getPatternBackground(fileImages, item);
-
-        if (!value) return null;
-
-        return (
-          <Square
-            key={item._ref}
-            background={value}
-            onClick={() => onChange?.(item)}
-          />
-        );
-      }),
-    [fileImages, imageAssets, onChange],
-  );
-
   return (
     <>
       <Divider />
-      <PaddedSection>
-        <Row>
+      <InspectorPrimitives.Section>
+        <InspectorPrimitives.Row>
           <Select
             id="document-images"
             options={['Document Images']}
             value="Document Images"
             onChange={() => {}}
           />
-          <Spacer.Horizontal size={8} />
-        </Row>
-      </PaddedSection>
-      <PaddedSection>
-        <GridSmall>{elements}</GridSmall>
-      </PaddedSection>
+        </InspectorPrimitives.Row>
+      </InspectorPrimitives.Section>
+      {imageAssets.length > 0 && (
+        <InspectorPrimitives.Section>
+          <GridSmall>
+            {imageAssets.map((item) => (
+              <Square
+                key={item._ref}
+                background={getPatternBackground(fileImages, item)}
+                onClick={() => onChange(item)}
+              />
+            ))}
+          </GridSmall>
+        </InspectorPrimitives.Section>
+      )}
     </>
   );
 });

--- a/packages/app/src/components/inspector/PickerSwatches.tsx
+++ b/packages/app/src/components/inspector/PickerSwatches.tsx
@@ -9,12 +9,11 @@ import {
 } from 'noya-designsystem';
 import { uuid } from 'noya-renderer';
 import { memo, useCallback, useState } from 'react';
+import * as InspectorPrimitives from '../inspector/InspectorPrimitives';
 import {
   GridSmall,
-  LayoutPicker,
+  LayoutRadioGroup,
   LayoutType,
-  PaddedSection,
-  Row,
   Square,
 } from './PickerAssetGrid';
 
@@ -101,20 +100,20 @@ export default memo(function PickerSwatches({
 
   return (
     <>
-      <PaddedSection>
+      <InspectorPrimitives.Section>
         {isSwatch ? (
           <Button id="detach-theme-color" onClick={onDetach}>
             Detach Theme Color
           </Button>
         ) : (
-          <Button id="crete-theme-color" onClick={handleCreate}>
+          <Button id="create-theme-color" onClick={handleCreate}>
             Create Theme Color
           </Button>
         )}
-      </PaddedSection>
+      </InspectorPrimitives.Section>
       <Divider />
-      <PaddedSection>
-        <Row>
+      <InspectorPrimitives.Section>
+        <InspectorPrimitives.Row>
           <Select
             id="colors-category"
             options={['Theme colors']}
@@ -122,24 +121,26 @@ export default memo(function PickerSwatches({
             onChange={() => {}}
           />
           <Spacer.Horizontal size={8} />
-          <LayoutPicker layout={swatchLayout} setLayout={setSwatchLayout} />
-        </Row>
-      </PaddedSection>
-      <PaddedSection>
-        {swatchLayout === 'grid' ? (
-          <SwatchesGrid
-            selectedId={selectedId}
-            swatches={swatches}
-            onSelect={onChange}
-          />
-        ) : (
-          <SwatchesList
-            selectedId={selectedId}
-            swatches={swatches}
-            onSelect={onChange}
-          />
-        )}
-      </PaddedSection>
+          <LayoutRadioGroup layout={swatchLayout} setLayout={setSwatchLayout} />
+        </InspectorPrimitives.Row>
+      </InspectorPrimitives.Section>
+      {swatches.length > 0 && (
+        <InspectorPrimitives.Section>
+          {swatchLayout === 'grid' ? (
+            <SwatchesGrid
+              selectedId={selectedId}
+              swatches={swatches}
+              onSelect={onChange}
+            />
+          ) : (
+            <SwatchesList
+              selectedId={selectedId}
+              swatches={swatches}
+              onSelect={onChange}
+            />
+          )}
+        </InspectorPrimitives.Section>
+      )}
     </>
   );
 });

--- a/packages/app/src/components/inspector/PickerSwatches.tsx
+++ b/packages/app/src/components/inspector/PickerSwatches.tsx
@@ -1,121 +1,113 @@
 import type Sketch from '@sketch-hq/sketch-file-format-ts';
 import {
-  Spacer,
-  Select,
-  sketchColorToRgbaString,
-  ListView,
   Button,
   Divider,
+  ListView,
+  Select,
+  sketchColorToRgbaString,
+  Spacer,
 } from 'noya-designsystem';
-import { memo, useMemo, useState } from 'react';
+import { uuid } from 'noya-renderer';
+import { memo, useCallback, useState } from 'react';
 import {
-  PaddedSection,
   GridSmall,
+  LayoutPicker,
+  LayoutType,
+  PaddedSection,
   Row,
   Square,
-  LayoutType,
-  LayoutPicker,
 } from './PickerAssetGrid';
 
 interface SwatchesProps {
-  selectedSwatchId?: string;
+  selectedId?: string;
   swatches: Sketch.Swatch[];
-  onSelectSwatch: (color: Sketch.Color) => void;
+  onSelect: (id: string) => void;
 }
 
 const SwatchesList = memo(function SwatchesList({
-  selectedSwatchId,
+  selectedId,
   swatches,
-  onSelectSwatch,
+  onSelect,
 }: SwatchesProps) {
   return (
     <ListView.Root>
-      {swatches.map((item) => {
-        const colorString = sketchColorToRgbaString(item.value);
-
-        return (
-          <ListView.Row
-            id={item.do_objectID}
-            key={item.do_objectID}
-            selected={selectedSwatchId === item.do_objectID}
-            onClick={() => {
-              onSelectSwatch({
-                ...item.value,
-                swatchID: item.do_objectID,
-              });
-            }}
-          >
-            <Square background={colorString} />
-            <Spacer.Horizontal size={8} />
-            {item.name}
-          </ListView.Row>
-        );
-      })}
+      {swatches.map((item) => (
+        <ListView.Row
+          id={item.do_objectID}
+          key={item.do_objectID}
+          selected={selectedId === item.do_objectID}
+          onClick={() => {
+            onSelect(item.do_objectID);
+          }}
+        >
+          <Square background={sketchColorToRgbaString(item.value)} />
+          <Spacer.Horizontal size={8} />
+          {item.name}
+        </ListView.Row>
+      ))}
     </ListView.Root>
   );
 });
 
 const SwatchesGrid = memo(function SwatchesGrid({
-  selectedSwatchId,
+  selectedId,
   swatches,
-  onSelectSwatch,
+  onSelect,
 }: SwatchesProps) {
   return (
     <GridSmall>
-      {swatches.map((item) => {
-        const colorString = sketchColorToRgbaString(item.value);
-
-        return (
-          <Square
-            key={item.do_objectID}
-            background={colorString}
-            selected={selectedSwatchId === item.do_objectID}
-            onClick={() => {
-              onSelectSwatch({
-                ...item.value,
-                swatchID: item.do_objectID,
-              });
-            }}
-          />
-        );
-      })}
+      {swatches.map((item) => (
+        <Square
+          key={item.do_objectID}
+          background={sketchColorToRgbaString(item.value)}
+          selected={selectedId === item.do_objectID}
+          onClick={() => {
+            onSelect(item.do_objectID);
+          }}
+        />
+      ))}
     </GridSmall>
   );
 });
 
 interface Props {
-  swatchID?: string;
-  sharedSwatches: Sketch.Swatch[];
-  onChange: (color: Sketch.Color) => void;
-  onCreate: () => void;
+  selectedId?: string;
+  swatches: Sketch.Swatch[];
+  onChange: (swatchID: string) => void;
+  onCreate: (swatchID: string, name: string) => void;
   onDetach: () => void;
 }
 
-export default memo(function ColorPickerSwatches({
-  swatchID,
-  sharedSwatches,
+export default memo(function PickerSwatches({
+  selectedId,
+  swatches,
   onChange,
   onCreate,
   onDetach,
 }: Props) {
   const [swatchLayout, setSwatchLayout] = useState<LayoutType>('grid');
 
-  const isSwatch = useMemo(
-    () =>
-      swatchID !== undefined &&
-      sharedSwatches.some((e) => e.do_objectID === swatchID),
-    [swatchID, sharedSwatches],
-  );
+  const isSwatch = swatches.some((e) => e.do_objectID === selectedId);
+
+  const handleCreate = useCallback(() => {
+    const swatchName = prompt('New Theme Color Name');
+
+    if (!swatchName) return;
+
+    const id = uuid();
+
+    onCreate(id, swatchName);
+  }, [onCreate]);
 
   return (
     <>
       <PaddedSection>
         {isSwatch ? (
-          <Button id={'detach-theme-color'} onClick={onDetach}>
+          <Button id="detach-theme-color" onClick={onDetach}>
             Detach Theme Color
           </Button>
         ) : (
-          <Button id={'crete-theme-color'} onClick={onCreate}>
+          <Button id="crete-theme-color" onClick={handleCreate}>
             Create Theme Color
           </Button>
         )}
@@ -136,15 +128,15 @@ export default memo(function ColorPickerSwatches({
       <PaddedSection>
         {swatchLayout === 'grid' ? (
           <SwatchesGrid
-            selectedSwatchId={swatchID}
-            swatches={sharedSwatches}
-            onSelectSwatch={onChange}
+            selectedId={selectedId}
+            swatches={swatches}
+            onSelect={onChange}
           />
         ) : (
           <SwatchesList
-            selectedSwatchId={swatchID}
-            swatches={sharedSwatches}
-            onSelectSwatch={onChange}
+            selectedId={selectedId}
+            swatches={swatches}
+            onSelect={onChange}
           />
         )}
       </PaddedSection>

--- a/packages/app/src/components/inspector/ShadowRow.tsx
+++ b/packages/app/src/components/inspector/ShadowRow.tsx
@@ -1,47 +1,39 @@
-import type Sketch from '@sketch-hq/sketch-file-format-ts';
 import { Label, LabeledElementView, Spacer } from 'noya-designsystem';
 import { SetNumberMode } from 'noya-state';
 import { memo, ReactNode, useCallback } from 'react';
-import styled from 'styled-components';
+import * as InspectorPrimitives from '../inspector/InspectorPrimitives';
 import DimensionInput from './DimensionInput';
 import { DimensionValue } from './DimensionsInspector';
-import FillInputFieldWithPicker from './FillInputFieldWithPicker';
-
-const Row = styled.div(({ theme }) => ({
-  flex: '1',
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-}));
+import FillInputFieldWithPicker, {
+  ColorFillProps,
+} from './FillInputFieldWithPicker';
 
 interface Props {
   id: string;
-  color?: Sketch.Color;
+  prefix?: ReactNode;
   x: DimensionValue;
   y: DimensionValue;
   blur: DimensionValue;
   spread: DimensionValue;
-  onChangeColor: (color: Sketch.Color) => void;
   onSetX: (value: number, mode: SetNumberMode) => void;
   onSetY: (value: number, mode: SetNumberMode) => void;
   onSetBlur: (value: number, mode: SetNumberMode) => void;
   onSetSpread: (value: number, mode: SetNumberMode) => void;
-  prefix?: ReactNode;
+  colorProps: ColorFillProps;
 }
 
 export default memo(function FillRow({
   id,
-  color,
+  prefix,
   x,
   y,
   blur,
   spread,
-  onChangeColor,
   onSetX,
   onSetY,
   onSetBlur,
   onSetSpread,
-  prefix,
+  colorProps,
 }: Props) {
   const colorInputId = `${id}-color`;
   const xInputId = `${id}-x`;
@@ -70,15 +62,11 @@ export default memo(function FillRow({
   );
 
   return (
-    <Row id={id}>
+    <InspectorPrimitives.Row id={id}>
       <LabeledElementView renderLabel={renderLabel}>
         {prefix}
         {prefix && <Spacer.Horizontal size={8} />}
-        <FillInputFieldWithPicker
-          id={colorInputId}
-          value={color}
-          onChange={onChangeColor}
-        />
+        <FillInputFieldWithPicker id={colorInputId} colorProps={colorProps} />
         <Spacer.Horizontal size={8} />
         <DimensionInput
           id={xInputId}
@@ -108,6 +96,6 @@ export default memo(function FillRow({
           onSetValue={onSetSpread}
         />
       </LabeledElementView>
-    </Row>
+    </InspectorPrimitives.Row>
   );
 });

--- a/packages/app/src/components/inspector/SymbolSourceRow.tsx
+++ b/packages/app/src/components/inspector/SymbolSourceRow.tsx
@@ -1,6 +1,6 @@
 import Sketch from '@sketch-hq/sketch-file-format-ts';
 import { Spacer } from 'noya-designsystem';
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import FillInputFieldWithPicker from './FillInputFieldWithPicker';
 import * as InspectorPrimitives from './InspectorPrimitives';
 
@@ -71,8 +71,13 @@ export default memo(function SymbolSourceRow({
         <Spacer.Horizontal size={65} />
         <FillInputFieldWithPicker
           id={'colorInputId'}
-          value={backgroundColor}
-          onChange={setBackgroundColor}
+          colorProps={useMemo(
+            () => ({
+              color: backgroundColor,
+              onChangeColor: setBackgroundColor,
+            }),
+            [backgroundColor, setBackgroundColor],
+          )}
         />
       </InspectorPrimitives.Row>
       {hasBackgroundColor && (

--- a/packages/app/src/components/inspector/TextStyleRow.tsx
+++ b/packages/app/src/components/inspector/TextStyleRow.tsx
@@ -103,7 +103,6 @@ export default memo(function TextStyleRow({
       <InspectorPrimitives.SectionHeader>
         <InspectorPrimitives.Title>Text</InspectorPrimitives.Title>
       </InspectorPrimitives.SectionHeader>
-
       <Spacer.Vertical size={10} />
       <InspectorPrimitives.Row>
         <Select
@@ -114,7 +113,6 @@ export default memo(function TextStyleRow({
           onChange={onChangeFontFamily}
         />
       </InspectorPrimitives.Row>
-
       <Spacer.Vertical size={6} />
       <InspectorPrimitives.Row>
         <Select
@@ -134,7 +132,6 @@ export default memo(function TextStyleRow({
           <InputField.Label>px</InputField.Label>
         </InputField.Root>
       </InspectorPrimitives.Row>
-
       <Spacer.Vertical size={6} />
       <InspectorPrimitives.Row>
         <LabeledElementView renderLabel={renderLabel}>
@@ -164,8 +161,13 @@ export default memo(function TextStyleRow({
           <Spacer.Horizontal size={8} />
           <FillInputFieldWithPicker
             id={'colorInputId'}
-            value={fontColor}
-            onChange={onChangeFontColor}
+            colorProps={useMemo(
+              () => ({
+                color: fontColor,
+                onChangeColor: onChangeFontColor,
+              }),
+              [fontColor, onChangeFontColor],
+            )}
           />
         </LabeledElementView>
       </InspectorPrimitives.Row>

--- a/packages/app/src/containers/BorderInspector.tsx
+++ b/packages/app/src/containers/BorderInspector.tsx
@@ -57,45 +57,39 @@ export default memo(function BorderInspector() {
         }) => (
           <BorderRow
             id={`border-${index}`}
-            value={
-              item.fillType === Sketch.FillType.Color
-                ? item.color
-                : item.gradient
-            }
             prefix={checkbox}
+            fillType={item.fillType}
             width={item.thickness}
             position={item.position}
-            onNudgeWidth={(value) =>
-              dispatch('setBorderWidth', index, value, 'adjust')
+            onSetWidth={(value, mode) =>
+              dispatch('setBorderWidth', index, value, mode)
             }
-            onChangeWidth={(value) => dispatch('setBorderWidth', index, value)}
-            onChangeColor={(value) => {
-              dispatch('setBorderColor', index, value);
-            }}
             onChangePosition={(value) => {
               dispatch('setBorderPosition', index, value);
             }}
             onChangeFillType={(value) =>
               dispatch('setBorderFillType', index, value)
             }
-            onChangeGradientColor={(value, stopIndex) =>
-              dispatch('setBorderGradientColor', index, stopIndex, value)
-            }
-            onChangeGradientPosition={(value, stopIndex) => {
-              dispatch('setBorderGradientPosition', index, stopIndex, value);
+            colorProps={{
+              color: item.color,
+              onChangeColor: (value) =>
+                dispatch('setBorderColor', index, value),
             }}
-            onAddGradientStop={(color, position) =>
-              dispatch('addBorderGradientStop', index, color, position)
-            }
-            onDeleteGradientStop={(value) =>
-              dispatch('deleteBorderGradientStop', index, value)
-            }
-            onChangeGradientType={(value) =>
-              dispatch('setBorderGradientType', index, value)
-            }
-            onChangeGradient={(value) =>
-              dispatch('setBorderGradient', index, value)
-            }
+            gradientProps={{
+              gradient: item.gradient,
+              onChangeGradientColor: (value, stopIndex) =>
+                dispatch('setBorderGradientColor', index, stopIndex, value),
+              onChangeGradientPosition: (value, stopIndex) =>
+                dispatch('setBorderGradientPosition', index, stopIndex, value),
+              onAddGradientStop: (color, position) =>
+                dispatch('addBorderGradientStop', index, color, position),
+              onDeleteGradientStop: (value) =>
+                dispatch('deleteBorderGradientStop', index, value),
+              onChangeGradientType: (value) =>
+                dispatch('setBorderGradientType', index, value),
+              onChangeGradient: (value) =>
+                dispatch('setBorderGradient', index, value),
+            }}
           />
         ),
         [dispatch],

--- a/packages/app/src/containers/FillInspector.tsx
+++ b/packages/app/src/containers/FillInspector.tsx
@@ -65,63 +65,51 @@ export default memo(function FillInspector({
         }) => (
           <FillRow
             id={`fill-${index}`}
-            value={
-              item.fillType === Sketch.FillType.Gradient
-                ? item.gradient
-                : item.fillType === Sketch.FillType.Color
-                ? item.color
-                : {
-                    _class: 'pattern',
-                    image: item.image,
-                    patternFillType: item.patternFillType,
-                    patternTileScale: item.patternTileScale,
-                  }
-            }
-            contextOpacity={item.contextSettings.opacity}
             prefix={checkbox}
+            fillType={item.fillType}
+            contextOpacity={item.contextSettings.opacity}
+            onSetOpacity={(value, mode) =>
+              dispatch('setFillOpacity', index, value, mode)
+            }
+            onSetContextOpacity={(value, mode) =>
+              dispatch('setFillContextSettingsOpacity', index, value, mode)
+            }
             onChangeFillType={(value) =>
               dispatch('setFillFillType', index, value)
             }
-            onChangeGradientColor={(value, stopIndex) =>
-              dispatch('setFillGradientColor', index, stopIndex, value)
-            }
-            onChangeGradientPosition={(value, stopIndex) => {
-              dispatch('setFillGradientPosition', index, stopIndex, value);
+            colorProps={{
+              color: item.color,
+              onChangeColor: (value) => dispatch('setFillColor', index, value),
             }}
-            onAddGradientStop={(color, position) =>
-              dispatch('addFillGradientStop', index, color, position)
-            }
-            onDeleteGradientStop={(value) =>
-              dispatch('deleteFillGradientStop', index, value)
-            }
-            onChangeGradientType={(value) =>
-              dispatch('setFillGradientType', index, value)
-            }
-            onChangeGradient={(value) =>
-              dispatch('setFillGradient', index, value)
-            }
-            onChangeOpacity={(value) =>
-              dispatch('setFillOpacity', index, value)
-            }
-            onNudgeOpacity={(value) =>
-              dispatch('setFillOpacity', index, value, 'adjust')
-            }
-            onChangeColor={(value) => dispatch('setFillColor', index, value)}
-            onChangeFillImage={(value) =>
-              dispatch('setFillImage', index, value)
-            }
-            onChangePatternFillType={(value) =>
-              dispatch('setPatternFillType', index, value)
-            }
-            onChangePatternTileScale={(value) =>
-              dispatch('setPatternTileScale', index, value)
-            }
-            onChangeContextOpacity={(value) =>
-              dispatch('setFillContextSettingsOpacity', index, value)
-            }
-            onNudgeContextOpacity={(value) =>
-              dispatch('setFillContextSettingsOpacity', index, value, 'adjust')
-            }
+            gradientProps={{
+              gradient: item.gradient,
+              onChangeGradientColor: (value, stopIndex) =>
+                dispatch('setFillGradientColor', index, stopIndex, value),
+              onChangeGradientPosition: (value, stopIndex) =>
+                dispatch('setFillGradientPosition', index, stopIndex, value),
+              onAddGradientStop: (color, position) =>
+                dispatch('addFillGradientStop', index, color, position),
+              onDeleteGradientStop: (value) =>
+                dispatch('deleteFillGradientStop', index, value),
+              onChangeGradientType: (value) =>
+                dispatch('setFillGradientType', index, value),
+              onChangeGradient: (value) =>
+                dispatch('setFillGradient', index, value),
+            }}
+            patternProps={{
+              pattern: {
+                _class: 'pattern',
+                patternFillType: item.patternFillType,
+                patternTileScale: item.patternTileScale,
+                image: item.image,
+              },
+              onChangeFillImage: (value) =>
+                dispatch('setFillImage', index, value),
+              onChangePatternFillType: (value) =>
+                dispatch('setPatternFillType', index, value),
+              onChangePatternTileScale: (value) =>
+                dispatch('setPatternTileScale', index, value),
+            }}
           />
         ),
 

--- a/packages/app/src/containers/ShadowInspector.tsx
+++ b/packages/app/src/containers/ShadowInspector.tsx
@@ -86,13 +86,11 @@ export default memo(function ShadowInspector() {
         }) => (
           <ShadowRow
             id={`shadow-${index}`}
-            color={item.color}
+            prefix={checkbox}
             x={item.offsetX}
             y={item.offsetY}
             blur={item.blurRadius}
             spread={item.spread}
-            prefix={checkbox}
-            onChangeColor={(value) => dispatch('setShadowColor', index, value)}
             onSetX={(value, mode) => dispatch('setShadowX', index, value, mode)}
             onSetY={(value, mode) => dispatch('setShadowY', index, value, mode)}
             onSetBlur={(value, mode) =>
@@ -101,6 +99,11 @@ export default memo(function ShadowInspector() {
             onSetSpread={(value, mode) =>
               dispatch('setShadowSpread', index, value, mode)
             }
+            colorProps={{
+              color: item.color,
+              onChangeColor: (value) =>
+                dispatch('setShadowColor', index, value),
+            }}
           />
         ),
         [dispatch],

--- a/packages/app/src/containers/SwatchesInspector.tsx
+++ b/packages/app/src/containers/SwatchesInspector.tsx
@@ -2,7 +2,6 @@ import { Divider } from 'noya-designsystem';
 import { Selectors } from 'noya-state';
 import { delimitedPath, isDeepEqual } from 'noya-utils';
 import { memo, useCallback } from 'react';
-import styled from 'styled-components';
 import ColorInspector from '../components/inspector/ColorInspector';
 import NameInspector from '../components/inspector/NameInspector';
 import {
@@ -11,12 +10,6 @@ import {
 } from '../contexts/ApplicationStateContext';
 import useShallowArray from '../hooks/useShallowArray';
 import getMultiValue from '../utils/getMultiValue';
-
-const Container = styled.div(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  padding: '10px',
-}));
 
 export default memo(function SwatchesInspectors() {
   const [state, dispatch] = useApplicationState();
@@ -59,14 +52,12 @@ export default memo(function SwatchesInspectors() {
         onNameChange={handleNameChange}
       />
       <Divider />
-      <Container>
-        <ColorInspector
-          id={'color-swatch'}
-          color={color}
-          onSetOpacity={handleSetOpacity}
-          onChangeColor={handleChangeColor}
-        />
-      </Container>
+      <ColorInspector
+        id={'color-swatch'}
+        color={color}
+        onSetOpacity={handleSetOpacity}
+        onChangeColor={handleChangeColor}
+      />
     </>
   );
 });

--- a/packages/noya-designsystem/src/components/ColorPicker.tsx
+++ b/packages/noya-designsystem/src/components/ColorPicker.tsx
@@ -47,7 +47,6 @@ export default memo(function ColorPicker({
       color={rgbaColor}
       onChange={handleChange}
     >
-      <Spacer.Vertical size={12} />
       <Saturation />
       <Spacer.Vertical size={12} />
       <Hue />

--- a/packages/noya-designsystem/src/components/LabeledElementView.tsx
+++ b/packages/noya-designsystem/src/components/LabeledElementView.tsx
@@ -2,6 +2,7 @@ import * as kiwi from 'kiwi.js';
 import {
   Children,
   createRef,
+  Fragment,
   isValidElement,
   memo,
   ReactNode,
@@ -41,6 +42,11 @@ export default memo(function LabeledElementView({
   renderLabel,
 }: ContainerProps) {
   const elementIds: string[] = Children.toArray(children)
+    .flatMap((child) =>
+      isValidElement(child) && child.type === Fragment
+        ? (child.props.children as ReactNode[])
+        : [child],
+    )
     .map((child) =>
       isValidElement(child) && 'id' in child.props ? child.props.id : null,
     )


### PR DESCRIPTION
This is mainly a refactor of the `FillInputFieldWithPicker`, and everything that renders it. I improved the "prop drilling" and optional props issues by bundling props together into groups:

- `colorProps`
- `gradientProps`
- `patternProps`

This also fixes an issue where we showed invalid fill types for shadows and borders. E.g. shadows can only accept color fills.

Aside from that, some misc UI cleanup.

This refactor should make it easier to support inspecting multiple borders and fills, which I plan to add next.