### PR TITLE
Refactor layer fill

### DIFF
--- a/packages/noya-renderer/src/__tests__/index.test.ts
+++ b/packages/noya-renderer/src/__tests__/index.test.ts
@@ -40,6 +40,7 @@ test('converts rect', async () => {
 });
 
 test('converts fill', async () => {
+  const frame = { x: 0, y: 0, width: 100, height: 100 };
   const paint = fill(
     ck,
     {
@@ -94,7 +95,7 @@ test('converts fill', async () => {
       patternFillType: 1,
       patternTileScale: 1,
     },
-    ck.Matrix.identity(),
+    frame,
   );
   expect(paint.getColor()).toMatchSnapshot();
 });

--- a/packages/noya-renderer/src/components/LayerPreview.tsx
+++ b/packages/noya-renderer/src/components/LayerPreview.tsx
@@ -53,21 +53,27 @@ export default function LayerPreview({
       ? resizeIfLarger(layerSize, paddedSize)
       : resize(layerSize, paddedSize);
 
-  // Scale the largest side to fit, if needed
-  const scale = Math.max(
-    scaledRect.width / layerSize.width,
-    scaledRect.height / layerSize.height,
-  );
-
   const transform = useMemo(() => {
     return AffineTransform.multiply(
       // Translate to the center of the size
       AffineTransform.translation(size.width / 2, size.height / 2),
-      AffineTransform.scale(scale),
+      AffineTransform.scale(
+        scaledRect.width / layerSize.width,
+        scaledRect.height / layerSize.height,
+      ),
       // Translate to (0,0) before scaling, since scale is applied at the origin
       AffineTransform.translation(-bounds.midX, -bounds.midY),
     );
-  }, [size.width, size.height, scale, bounds.midX, bounds.midY]);
+  }, [
+    size.width,
+    size.height,
+    scaledRect.width,
+    scaledRect.height,
+    layerSize.width,
+    layerSize.height,
+    bounds.midX,
+    bounds.midY,
+  ]);
 
   return (
     <>

--- a/packages/noya-renderer/src/components/layers/SketchShape.tsx
+++ b/packages/noya-renderer/src/components/layers/SketchShape.tsx
@@ -17,41 +17,26 @@ import { Rect } from '../../../../noya-state/src';
 import { getStrokedPath } from '../../primitives/path';
 import SketchBorder from '../effects/SketchBorder';
 
-/**
- * CanvasKit draws gradients in absolute coordinates, while Sketch draws them
- * relative to the layer's frame. This function returns a matrix that converts
- * absolute coordinates into the range (0, 1).
- */
-export function getGradientTransformationMatrix(
-  CanvasKit: CanvasKit.CanvasKit,
-  rect: Sketch.Rect,
-): number[] {
-  return CanvasKit.Matrix.multiply(
-    CanvasKit.Matrix.translated(rect.x, rect.y),
-    CanvasKit.Matrix.scaled(rect.width, rect.height),
-  );
-}
-
 const SketchFill = memo(function SketchFill({
   path,
   fill,
-  transform,
   frame,
   image,
 }: {
   path: CanvasKit.Path;
   fill: Sketch.Fill;
-  transform: number[];
   frame: Rect;
   image?: ArrayBuffer;
 }) {
   const { CanvasKit } = useReactCanvasKit();
 
   // TODO: Delete internal gradient shaders on unmount
-  const paint = useMemo(
-    () => Primitives.fill(CanvasKit, fill, transform, frame, image),
-    [CanvasKit, fill, transform, frame, image],
-  );
+  const paint = useMemo(() => Primitives.fill(CanvasKit, fill, frame, image), [
+    CanvasKit,
+    fill,
+    frame,
+    image,
+  ]);
 
   useDeletable(paint);
 
@@ -191,11 +176,6 @@ export default memo(function SketchShape({ layer }: Props) {
 
   path.setFillType(CanvasKit.FillType.EvenOdd);
 
-  const transform = useMemo(
-    () => getGradientTransformationMatrix(CanvasKit, layer.frame),
-    [CanvasKit, layer.frame],
-  );
-
   if (!layer.style) return null;
 
   const fills = (layer.style.fills ?? []).filter((x) => x.isEnabled);
@@ -237,7 +217,6 @@ export default memo(function SketchShape({ layer }: Props) {
           key={`fill-${index}`}
           fill={fill}
           path={path}
-          transform={transform}
           frame={layer.frame}
           image={fill.image ? state.sketch.images[fill.image._ref] : undefined}
         />

--- a/packages/noya-renderer/src/primitives.ts
+++ b/packages/noya-renderer/src/primitives.ts
@@ -62,8 +62,7 @@ export function clearColor(CanvasKit: CanvasKit) {
 export function fill(
   CanvasKit: CanvasKit,
   fill: Sketch.Fill,
-  localMatrix: Float32Array | number[],
-  layerFrame?: Rect,
+  layerFrame: Rect,
   image?: ArrayBuffer,
 ): Paint {
   const paint = new CanvasKit.Paint();
@@ -88,6 +87,14 @@ export function fill(
       const fromPoint = parsePoint(fill.gradient.from);
       const toPoint = parsePoint(fill.gradient.to);
 
+      // CanvasKit draws gradients in absolute coordinates, while Sketch draws them
+      // relative to the layer's frame. This function returns a matrix that converts
+      // absolute coordinates into the range (0, 1).
+      const unitTransform = CanvasKit.Matrix.multiply(
+        CanvasKit.Matrix.translated(layerFrame.x, layerFrame.y),
+        CanvasKit.Matrix.scaled(layerFrame.width, layerFrame.height),
+      );
+
       switch (fill.gradient.gradientType) {
         case Sketch.GradientType.Linear: {
           paint.setShader(
@@ -97,7 +104,7 @@ export function fill(
               colors,
               positions,
               CanvasKit.TileMode.Clamp,
-              localMatrix,
+              unitTransform,
             ),
           );
           break;
@@ -110,7 +117,7 @@ export function fill(
               colors,
               positions,
               CanvasKit.TileMode.Clamp,
-              localMatrix,
+              unitTransform,
             ),
           );
           break;
@@ -143,10 +150,10 @@ export function fill(
           const matrix =
             rotationRadians > 0
               ? CanvasKit.Matrix.multiply(
-                  localMatrix,
+                  unitTransform,
                   CanvasKit.Matrix.rotated(rotationRadians, 0.5, 0.5),
                 )
-              : localMatrix;
+              : unitTransform;
 
           paint.setShader(
             CanvasKit.Shader.MakeSweepGradient(
@@ -189,24 +196,7 @@ export function fill(
           );
           break;
         }
-        case Sketch.PatternFillType.Stretch: {
-          paint.setShader(
-            canvasImage.makeShaderCubic(
-              CanvasKit.TileMode.Decal,
-              CanvasKit.TileMode.Decal,
-              0,
-              0,
-              CanvasKit.Matrix.multiply(
-                CanvasKit.Matrix.translated(layerFrame.x, layerFrame.y),
-                CanvasKit.Matrix.scaled(
-                  layerFrame.width / canvasImage.width(),
-                  layerFrame.height / canvasImage.height(),
-                ),
-              ),
-            ),
-          );
-          break;
-        }
+        case Sketch.PatternFillType.Stretch:
         case Sketch.PatternFillType.Fit:
         case Sketch.PatternFillType.Fill: {
           const bounds = createBounds(layerFrame);
@@ -217,15 +207,11 @@ export function fill(
               height: canvasImage.height(),
             },
             layerFrame,
-            fill.patternFillType === Sketch.PatternFillType.Fit
+            fill.patternFillType === Sketch.PatternFillType.Stretch
+              ? 'scaleToFill'
+              : fill.patternFillType === Sketch.PatternFillType.Fit
               ? 'scaleAspectFit'
               : 'scaleAspectFill',
-          );
-
-          // Scale the largest side to fit, if needed
-          const scale = Math.max(
-            scaledRect.width / canvasImage.width(),
-            scaledRect.height / canvasImage.height(),
           );
 
           paint.setShader(
@@ -239,7 +225,10 @@ export function fill(
                   bounds.midX - scaledRect.width / 2,
                   bounds.midY - scaledRect.height / 2,
                 ),
-                CanvasKit.Matrix.scaled(scale, scale),
+                CanvasKit.Matrix.scaled(
+                  scaledRect.width / canvasImage.width(),
+                  scaledRect.height / canvasImage.height(),
+                ),
               ),
             ),
           );


### PR DESCRIPTION
I found 2 things to simplify in our resizing code:

- We don't need to do `Math.max(...)` when scaling, since when the aspect ratio is preserved, the scale will be the same for both sides
- The stretch case can be combined into the other cases in `fill()`