### PR TITLE
adding support for closing path when clicking on qualified point

### DIFF
--- a/packages/app/src/containers/Canvas.tsx
+++ b/packages/app/src/containers/Canvas.tsx
@@ -290,11 +290,8 @@ export default memo(function Canvas() {
                 : 'replace',
             );
             dispatch('interaction', ['maybeMovePoint', point]);
-            const canClose = canClosePath(state, {
-              type: 'point',
-              value: selectedPoint,
-            });
-            if (canClose) dispatch('setIsClosed', true);
+            const canClose = canClosePath(state, selectedPoint);
+            if (canClose && !event.shiftKey) dispatch('setIsClosed', true);
           } else if (selectedControlPoint) {
             dispatch(
               'selectControlPoint',

--- a/packages/app/src/containers/Canvas.tsx
+++ b/packages/app/src/containers/Canvas.tsx
@@ -12,7 +12,10 @@ import {
   ShapeType,
 } from 'noya-state';
 import { SelectedPoint } from 'noya-state/src/reducers/pointReducer';
-import { getCursorForEditPathMode } from 'noya-state/src/selectors/elementSelectors';
+import {
+  canClosePath,
+  getCursorForEditPathMode,
+} from 'noya-state/src/selectors/elementSelectors';
 import { getBoundingRectMap } from 'noya-state/src/selectors/geometrySelectors';
 import { getSelectedLayers } from 'noya-state/src/selectors/layerSelectors';
 import { getCurrentPage } from 'noya-state/src/selectors/pageSelectors';
@@ -287,6 +290,11 @@ export default memo(function Canvas() {
                 : 'replace',
             );
             dispatch('interaction', ['maybeMovePoint', point]);
+            const canClose = canClosePath(state, {
+              type: 'point',
+              value: selectedPoint,
+            });
+            if (canClose) dispatch('setIsClosed', true);
           } else if (selectedControlPoint) {
             dispatch(
               'selectControlPoint',

--- a/packages/noya-keymap/src/index.ts
+++ b/packages/noya-keymap/src/index.ts
@@ -1,1 +1,2 @@
 export * from './hooks';
+export type { KeyModifiers } from './names';

--- a/packages/noya-state/src/reducers/applicationReducer.ts
+++ b/packages/noya-state/src/reducers/applicationReducer.ts
@@ -5,6 +5,7 @@ import { WritableDraft } from 'immer/dist/internal';
 import { uuid } from 'noya-renderer';
 import { SketchFile } from 'noya-sketch-file';
 import { IndexPath } from 'tree-visit';
+import { KeyModifiers } from 'noya-keymap';
 import * as Layers from '../layers';
 import {
   findPageLayerIndexPaths,
@@ -55,6 +56,7 @@ export type ApplicationState = {
   currentTab: WorkspaceTab;
   currentThemeTab: ThemeTab;
   interactionState: InteractionState;
+  keyModifiers: KeyModifiers;
   selectedPage: string;
   selectedObjects: string[];
   selectedPointLists: SelectedPointLists;
@@ -65,6 +67,7 @@ export type ApplicationState = {
 
 export type Action =
   | [type: 'setTab', value: WorkspaceTab]
+  | [type: 'setKeyModifier', name: keyof KeyModifiers, value: boolean]
   | PageAction
   | CanvasAction
   | LayerPropertyAction
@@ -83,6 +86,11 @@ export function applicationReducer(
   CanvasKit: CanvasKit,
 ): ApplicationState {
   switch (action[0]) {
+    case 'setKeyModifier':
+      const [, name, value] = action;
+      return produce(state, (draft) => {
+        draft.keyModifiers[name] = value;
+      });
     case 'setTab': {
       const [, value] = action;
       return produce(state, (draft) => {
@@ -334,6 +342,12 @@ export function createInitialState(sketch: SketchFile): ApplicationState {
     currentTab: 'canvas',
     currentThemeTab: 'swatches',
     interactionState: createInitialInteractionState(),
+    keyModifiers: {
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+    },
     selectedPage: sketch.pages[0].do_objectID,
     selectedObjects: [],
     selectedPointLists: {},

--- a/packages/noya-state/src/selectors/elementSelectors.ts
+++ b/packages/noya-state/src/selectors/elementSelectors.ts
@@ -22,6 +22,8 @@ type PathElement =
     };
 
 export function canClosePath(state: ApplicationState, element: SelectedPoint) {
+  if (state.keyModifiers.shiftKey) return false;
+
   const [layerId, index] = element;
 
   const layer = Layers.find(
@@ -55,7 +57,7 @@ export const getCursorForEditPathMode = (
   if (elementAtPoint) {
     return elementAtPoint.type === 'point' &&
       canClosePath(state, elementAtPoint.value)
-      ? 'no-drop'
+      ? 'pointer'
       : 'move';
   } else if (getIndexPathOfOpenShapeLayer(state)) {
     return 'crosshair';

--- a/packages/noya-state/src/selectors/elementSelectors.ts
+++ b/packages/noya-state/src/selectors/elementSelectors.ts
@@ -21,12 +21,30 @@ type PathElement =
       value: SelectedControlPoint;
     };
 
+export function canClosePath(state: ApplicationState, element: PathElement) {
+  if (element.type === 'point') {
+    const [layerId, index] = element.value;
+
+    const layers = getSelectedLayers(state)
+      .filter(Layers.isPointsLayer)
+      .filter((layer) => layer.do_objectID === layerId);
+
+    return (
+      (index === layers[0].points.length - 1 || index === 0) &&
+      !layers[0].isClosed &&
+      !state.selectedPointLists[layerId].includes(index)
+    );
+  }
+  return false;
+}
+
 export const getCursorForEditPathMode = (
   state: ApplicationState,
   point: Point,
 ) => {
-  if (getPathElementAtPoint(state, point)) {
-    return 'move';
+  const elementAtPoint = getPathElementAtPoint(state, point);
+  if (elementAtPoint) {
+    return canClosePath(state, elementAtPoint) ? 'no-drop' : 'move';
   } else if (getIndexPathOfOpenShapeLayer(state)) {
     return 'crosshair';
   } else {

--- a/packages/noya-state/src/selectors/elementSelectors.ts
+++ b/packages/noya-state/src/selectors/elementSelectors.ts
@@ -21,21 +21,30 @@ type PathElement =
       value: SelectedControlPoint;
     };
 
-export function canClosePath(state: ApplicationState, element: PathElement) {
-  if (element.type === 'point') {
-    const [layerId, index] = element.value;
+export function canClosePath(state: ApplicationState, element: SelectedPoint) {
+  const [layerId, index] = element;
 
-    const layers = getSelectedLayers(state)
-      .filter(Layers.isPointsLayer)
-      .filter((layer) => layer.do_objectID === layerId);
+  const layer = Layers.find(
+    getCurrentPage(state),
+    (layer) => layer.do_objectID === layerId,
+  );
 
-    return (
-      (index === layers[0].points.length - 1 || index === 0) &&
-      !layers[0].isClosed &&
-      !state.selectedPointLists[layerId].includes(index)
-    );
-  }
-  return false;
+  if (!layer || !Layers.isPointsLayer(layer)) return false;
+
+  // A path needs at least 2 points to be closed.
+  // TODO: Don't allow closing a straight line segment with 2 points.
+  if (layer.points.length < 2) return false;
+
+  const selectedPoint = getIndexPathOfOpenShapeLayer(state);
+
+  if (!selectedPoint) return false;
+
+  const lastIndex = layer.points.length - 1;
+
+  return (
+    (index === lastIndex && selectedPoint.pointIndex === 0) ||
+    (index === 0 && selectedPoint.pointIndex === lastIndex)
+  );
 }
 
 export const getCursorForEditPathMode = (
@@ -44,7 +53,10 @@ export const getCursorForEditPathMode = (
 ) => {
   const elementAtPoint = getPathElementAtPoint(state, point);
   if (elementAtPoint) {
-    return canClosePath(state, elementAtPoint) ? 'no-drop' : 'move';
+    return elementAtPoint.type === 'point' &&
+      canClosePath(state, elementAtPoint.value)
+      ? 'no-drop'
+      : 'move';
   } else if (getIndexPathOfOpenShapeLayer(state)) {
     return 'crosshair';
   } else {


### PR DESCRIPTION
The cursor 'no-drop' will appear when hovering over a point that, when clicked, will close the path of an open layer.