### PR TITLE
Add KeyCommandRegistry native module

### DIFF
--- a/packages/app-mobile/ios/KeyCommandRegistry.m
+++ b/packages/app-mobile/ios/KeyCommandRegistry.m
@@ -1,0 +1,16 @@
+//
+//  KeyCommandRegistry.m
+//  noyamobile
+//
+//  Created by Devin Abbott on 5/4/22.
+//
+
+#import "React/RCTViewManager.h"
+#import "React/RCTEventEmitter.h"
+
+@interface RCT_EXTERN_MODULE(KeyCommandRegistry, RCTEventEmitter)
+
+RCT_EXTERN_METHOD(registerCommand:(NSDictionary *)options)
+RCT_EXTERN_METHOD(unregisterCommand:(NSDictionary *)options)
+
+@end

--- a/packages/app-mobile/ios/KeyCommandRegistry.swift
+++ b/packages/app-mobile/ios/KeyCommandRegistry.swift
@@ -1,0 +1,125 @@
+//
+//  KeyCommandRegistry.swift
+//  noyamobile
+//
+//  Created by Devin Abbott on 5/4/22.
+//
+
+import Foundation
+import React
+
+@objc
+protocol KeyCommandable {
+  func onKeyCommand(keyCommand: UIKeyCommand) -> Void
+}
+
+@objc(KeyCommandRegistry)
+class KeyCommandRegistry: RCTEventEmitter {
+  
+  var commandMap: [String: UIKeyCommand] = [:]
+  
+  @objc
+  func registerCommand(_ options: NSDictionary) {
+    guard let command = options["command"] as? String else { return }
+    
+    let parts = command.split(separator: "-")
+    let key = String(parts.last ?? "")
+    let hasCommand = parts.contains("command")
+    let hasShift = parts.contains("shift")
+    let hasControl = parts.contains("control")
+    
+    if #available(iOS 13.0, *) {
+      var flags = UIKeyModifierFlags()
+      
+      if (hasCommand) { flags.insert(.command) }
+      if (hasShift) { flags.insert(.shift) }
+      if (hasControl) { flags.insert(.control) }
+      
+      let keyCommand = UIKeyCommand(
+        action: #selector(KeyCommandable.onKeyCommand(keyCommand:)),
+        input: key,
+        modifierFlags: flags
+      )
+      
+      if let title = options["title"] as? String {
+        keyCommand.title = title
+      }
+      
+      if #available(iOS 15.0, *) {
+        if let priority = options["priority"] as? String {
+          keyCommand.wantsPriorityOverSystemBehavior = priority == "system"
+        }
+      }
+      
+      commandMap[command] = keyCommand
+    }
+  }
+  
+  @objc
+  func unregisterCommand(_ options: NSDictionary) {
+    guard let command = options["command"] as? String else { return }
+    
+    commandMap.removeValue(forKey: command)
+  }
+  
+  // Overrides
+  
+  override func supportedEvents() -> [String]! {
+    return ["onKeyCommand"]
+  }
+  
+  override class func requiresMainQueueSetup() -> Bool {
+    return true
+  }
+  
+  override func startObserving() {
+    super.startObserving()
+    addToInstances()
+  }
+  
+  override func stopObserving() {
+    super.stopObserving()
+    removeFromInstances()
+  }
+  
+  override func invalidate() {
+    super.invalidate()
+    removeFromInstances()
+  }
+  
+  // Instances
+  
+  private func addToInstances() {
+    KeyCommandRegistry.instances.append(self)
+  }
+  
+  private func removeFromInstances() {
+    KeyCommandRegistry.instances.removeAll { $0 == self }
+  }
+  
+  /// Everytime the React Native bridge reloads, it instantiates a new instance of this KeyCommandRegistry.
+  /// We assume that key commands should affect every active instance, though in our case there should only
+  /// ever be one instance.
+  private static var instances: [KeyCommandRegistry] = []
+  
+  // API
+  
+  static func allCommands() -> [UIKeyCommand] {
+    var commands: [UIKeyCommand] = []
+    
+    instances.forEach { instance in
+      commands.append(contentsOf: instance.commandMap.values)
+    }
+    
+    return commands
+  }
+  
+  static func onKeyCommand(keyCommand: UIKeyCommand) {
+    KeyCommandRegistry.instances.forEach { instance in
+      instance.commandMap.forEach { command, value in
+        guard value === keyCommand else { return }
+        instance.sendEvent(withName: "onKeyCommand", body: ["command": command])
+      }
+    }
+  }
+}

--- a/packages/app-mobile/ios/RootViewController.swift
+++ b/packages/app-mobile/ios/RootViewController.swift
@@ -1,0 +1,20 @@
+//
+//  RootViewController.swift
+//  noyamobile
+//
+//  Created by Devin Abbott on 5/4/22.
+//
+
+import Foundation
+import UIKit
+
+@objc
+class RootViewController: UIViewController, KeyCommandable {
+  override var keyCommands: [UIKeyCommand] {
+    return KeyCommandRegistry.allCommands()
+  }
+  
+  func onKeyCommand(keyCommand: UIKeyCommand) {
+    KeyCommandRegistry.onKeyCommand(keyCommand: keyCommand)
+  }
+}

--- a/packages/app-mobile/ios/noyamobile-Bridging-Header.h
+++ b/packages/app-mobile/ios/noyamobile-Bridging-Header.h
@@ -1,0 +1,3 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//

--- a/packages/app-mobile/ios/noyamobile.xcodeproj/project.pbxproj
+++ b/packages/app-mobile/ios/noyamobile.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		44E0586A205C0C25B9F385E8 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1365128A42E7DA9351FF5E /* ExpoModulesProvider.swift */; };
 		6172F2D35A4C3AA820D92908 /* libPods-noyamobile.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6423831EA8574132BED9D8CC /* libPods-noyamobile.a */; };
+		6BB25707282353B700FE0754 /* KeyCommandRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB25706282353B700FE0754 /* KeyCommandRegistry.swift */; };
+		6BB25709282353D700FE0754 /* KeyCommandRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB25708282353D700FE0754 /* KeyCommandRegistry.m */; };
+		6BB2570B282353FD00FE0754 /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB2570A282353FD00FE0754 /* RootViewController.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
@@ -28,6 +31,10 @@
 		1D0AE47A65C8663E3B452821 /* Pods-noyamobile-noyamobileTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-noyamobile-noyamobileTests.release.xcconfig"; path = "Target Support Files/Pods-noyamobile-noyamobileTests/Pods-noyamobile-noyamobileTests.release.xcconfig"; sourceTree = "<group>"; };
 		4A1365128A42E7DA9351FF5E /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-noyamobile/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		6423831EA8574132BED9D8CC /* libPods-noyamobile.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-noyamobile.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6BB25706282353B700FE0754 /* KeyCommandRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCommandRegistry.swift; sourceTree = "<group>"; };
+		6BB25708282353D700FE0754 /* KeyCommandRegistry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KeyCommandRegistry.m; sourceTree = "<group>"; };
+		6BB2570A282353FD00FE0754 /* RootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewController.swift; sourceTree = "<group>"; };
+		6BB2570C2823545900FE0754 /* noyamobile-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "noyamobile-Bridging-Header.h"; sourceTree = "<group>"; };
 		6C97AB639B58BBB4B15BBE30 /* Pods-noyamobile-noyamobileTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-noyamobile-noyamobileTests.debug.xcconfig"; path = "Target Support Files/Pods-noyamobile-noyamobileTests/Pods-noyamobile-noyamobileTests.debug.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = noyamobile/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		ABFE59519B596E51CEFDCCC0 /* libPods-noyamobile-noyamobileTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-noyamobile-noyamobileTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -67,9 +74,12 @@
 		13B07FAE1A68108700A75B9A /* noyamobile */ = {
 			isa = PBXGroup;
 			children = (
+				6BB257052823538B00FE0754 /* KeyCommandRegistry */,
 				04AC522827A2D5E500219B82 /* noyamobile.entitlements */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				6BB2570A282353FD00FE0754 /* RootViewController.swift */,
+				6BB2570C2823545900FE0754 /* noyamobile-Bridging-Header.h */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
@@ -94,6 +104,15 @@
 				4A1365128A42E7DA9351FF5E /* ExpoModulesProvider.swift */,
 			);
 			name = noyamobile;
+			sourceTree = "<group>";
+		};
+		6BB257052823538B00FE0754 /* KeyCommandRegistry */ = {
+			isa = PBXGroup;
+			children = (
+				6BB25706282353B700FE0754 /* KeyCommandRegistry.swift */,
+				6BB25708282353D700FE0754 /* KeyCommandRegistry.m */,
+			);
+			name = KeyCommandRegistry;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
@@ -307,9 +326,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6BB25707282353B700FE0754 /* KeyCommandRegistry.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				6BB2570B282353FD00FE0754 /* RootViewController.swift in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				44E0586A205C0C25B9F385E8 /* ExpoModulesProvider.swift in Sources */,
+				6BB25709282353D700FE0754 /* KeyCommandRegistry.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -346,6 +368,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.design.noya.noyamobile;
 				PRODUCT_NAME = noyamobile;
 				SUPPORTS_MACCATALYST = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "noyamobile-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -383,6 +406,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.design.noya.noyamobile;
 				PRODUCT_NAME = noyamobile;
 				SUPPORTS_MACCATALYST = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "noyamobile-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";

--- a/packages/app-mobile/ios/noyamobile/AppDelegate.m
+++ b/packages/app-mobile/ios/noyamobile/AppDelegate.m
@@ -23,6 +23,8 @@ static void InitializeFlipper(UIApplication *application) {
 }
 #endif
 
+#import "noyamobile-Swift.h"
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -43,7 +45,8 @@ static void InitializeFlipper(UIApplication *application) {
   }
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+//  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  UIViewController *rootViewController = [RootViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];

--- a/packages/app-mobile/src/App/AppContent.tsx
+++ b/packages/app-mobile/src/App/AppContent.tsx
@@ -20,10 +20,11 @@ import MainMenu from '../containers/MainMenu';
 import PageList from '../containers/PageList';
 import Toolbar from '../containers/Toolbar';
 import Canvas from '../containers/Canvas';
+import { registerKeyCommand } from '../utils/KeyCommandRegistry';
 
 const AppContent: React.FC = () => {
   const { state, dispatch } = useAppState();
-  const [layersFilter, setLayersFilter] = useState('');
+  const [layersFilter] = useState('');
   const fontManager = useFontManager();
 
   const handleDispatch = useCallback(
@@ -34,6 +35,13 @@ const AppContent: React.FC = () => {
   );
 
   const downloadFont = useDownloadFont();
+
+  useEffect(() => {
+    return registerKeyCommand({ command: 'command-p', title: 'Print' }, () => {
+      // eslint-disable-next-line no-console
+      console.log('Print!');
+    });
+  }, []);
 
   // Whenever the sketch file updates, download any new fonts
   useEffect(() => {

--- a/packages/app-mobile/src/utils/KeyCommandRegistry.ts
+++ b/packages/app-mobile/src/utils/KeyCommandRegistry.ts
@@ -1,0 +1,88 @@
+import { NativeEventEmitter, NativeModule, NativeModules } from 'react-native';
+import { KeyedSet } from './KeyedSet';
+
+export type KeyCommandPriority = 'standard' | 'system';
+
+export type KeyCommand = {
+  command: string;
+  title?: string;
+  priority?: KeyCommandPriority;
+};
+
+const { KeyCommandRegistry } = NativeModules as {
+  KeyCommandRegistry: NativeModule & {
+    registerCommand: (options: KeyCommand) => void;
+    unregisterCommand: (options: { command: string }) => void;
+  };
+};
+
+const callbacks = new KeyedSet<string, () => void>();
+
+const eventEmitter = new NativeEventEmitter(KeyCommandRegistry);
+
+eventEmitter.addListener('onKeyCommand', (options: { command: string }) => {
+  callbacks.forEach(options.command, (callback) => callback());
+});
+
+function addCommand(options: KeyCommand, callback: () => void) {
+  callbacks.add(options.command, callback);
+
+  // If we have at least 1 command, add it to the native list of key commands.
+  if (callbacks.size(options.command) === 1) {
+    KeyCommandRegistry.registerCommand(options);
+  }
+}
+
+function deleteCommand(options: KeyCommand, callback: () => void) {
+  callbacks.delete(options.command, callback);
+
+  // If there are no commands left, remove it from the native list of key commands.
+  if (callbacks.size(options.command) === 0) {
+    KeyCommandRegistry.unregisterCommand(options);
+  }
+}
+
+/**
+ * We use the command string as an id, so it's important that
+ * a command string always has the same format.
+ *
+ * E.g. "command-shift-a" and "shift-command-a" should map to
+ * the same id.
+ */
+function normalizeCommand(command: string) {
+  const parts = command.toLowerCase().split('-');
+
+  const key = parts[parts.length - 1];
+  const hasCommand = parts.includes('command');
+  const hasShift = parts.includes('shift');
+  const hasOption = parts.includes('option');
+
+  return [
+    hasCommand && 'command',
+    hasShift && 'shift',
+    hasOption && 'option',
+    key,
+  ]
+    .flatMap((value) => (value ? [value] : []))
+    .join('-');
+}
+
+export function registerKeyCommand(
+  options: string | KeyCommand,
+  callback: () => void,
+) {
+  const optionsObject: KeyCommand =
+    typeof options === 'string' ? { command: options } : options;
+
+  const normalized: KeyCommand = {
+    priority: 'standard',
+    ...optionsObject,
+    command: normalizeCommand(optionsObject.command),
+  };
+
+  addCommand(normalized, callback);
+
+  return () => {
+    deleteCommand(normalized, callback);
+  };
+}

--- a/packages/app-mobile/src/utils/KeyedSet.ts
+++ b/packages/app-mobile/src/utils/KeyedSet.ts
@@ -1,0 +1,25 @@
+export class KeyedSet<K, V> {
+  map = new Map<K, Set<V>>();
+
+  private getSet(key: K) {
+    const set = this.map.get(key) ?? new Set();
+    this.map.set(key, set);
+    return set;
+  }
+
+  add(key: K, value: V) {
+    this.getSet(key).add(value);
+  }
+
+  delete(key: K, value: V) {
+    this.getSet(key).delete(value);
+  }
+
+  forEach(key: K, callback: (value: V) => void) {
+    this.getSet(key).forEach(callback);
+  }
+
+  size(key: K) {
+    return this.getSet(key).size;
+  }
+}


### PR DESCRIPTION
@michalsek feel free to move this stuff elsewhere or push to this branch. I mostly just wanted to include the files, and didn't think about the right place for them.

I pushed with `--no-verify` due to tsc having some errors on `app-mobile` for me... seemingly unrelated to these changes, but you never know

---

Pass `priority: 'system'` when registering to prevent the system default, similar to `event.preventDefault()`

Pass a title for the command to be included in the iOS command palette. I added a placeholder "Print" to the `AppContent` to demonstrate

![IMG_0007](https://user-images.githubusercontent.com/1198882/166850258-5864ecdc-10e1-4dc7-abe0-369b594112be.PNG)

