### PR TITLE
Open Graph meta tags for share with server-side rendering

### DIFF
--- a/packages/site/src/pages/share/[shareId].tsx
+++ b/packages/site/src/pages/share/[shareId].tsx
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { NoyaAPI, NoyaAPIProvider } from 'noya-api';
 import {
@@ -13,6 +14,7 @@ import {
 } from 'noya-designsystem';
 import { ArrowRightIcon } from 'noya-icons';
 import { amplitude } from 'noya-log';
+import { Layers } from 'noya-state';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Analytics } from '../../components/Analytics';
@@ -114,8 +116,48 @@ function Content({ shareId }: { shareId: string }) {
     return null;
   }
 
+  const artboard = Layers.find(
+    initialFile.data.document.pages[0],
+    Layers.isArtboard,
+  );
+
   return (
     <Stack.V flex="1" background={theme.colors.canvas.background}>
+      <Head>
+        <meta name="description" content="Created with Noya" />
+        {artboard && (
+          <>
+            <meta
+              property="og:url"
+              content={`${NOYA_HOST}/app/share/${initialFile.id}`}
+            />
+            <meta property="og:title" content={initialFile.data.name} />
+            <meta property="og:description" content="Created with Noya" />
+            <meta
+              property="og:image"
+              content={`${networkClient?.baseURI}/shares/${initialFile.id}.png?width=${artboard.frame.width}&height=${artboard.frame.height}`}
+            />
+            <meta
+              property="og:image:width"
+              content={`${artboard.frame.width}`}
+            />
+            <meta
+              property="og:image:height"
+              content={`${artboard.frame.height}`}
+            />
+            <meta property="og:image:user_generated" content="true" />
+            <meta property="og:type" content="article" />
+            <meta
+              property="og:article:published_time"
+              content={`${initialFile.createdAt}`}
+            />
+            <meta
+              property="og:article:modified_time"
+              content={`${initialFile.updatedAt}`}
+            />
+          </>
+        )}
+      </Head>
       <Toolbar>
         <Small>{initialFile.data.name}</Small>
         <Spacer.Horizontal size={8} inline />

--- a/packages/site/src/pages/share/[shareId]/preview.tsx
+++ b/packages/site/src/pages/share/[shareId]/preview.tsx
@@ -1,0 +1,150 @@
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
+import { NoyaAPI, NoyaAPIProvider } from 'noya-api';
+import {
+  Button,
+  DesignSystemConfigurationProvider,
+  lightTheme,
+  Small,
+  Spacer,
+  Stack,
+  useDesignSystemTheme,
+} from 'noya-designsystem';
+import { ArrowRightIcon } from 'noya-icons';
+import React, { useEffect, useState } from 'react';
+import { Analytics } from '../../../components/Analytics';
+import { addShareCookie } from '../../../utils/cookies';
+import { createNoyaClient, NOYA_HOST } from '../../../utils/noyaClient';
+
+const Ayon = dynamic(() => import('../../../components/Ayon'), { ssr: false });
+
+/**
+ * This client throws errors if the user isn't logged in
+ */
+const networkClient = NOYA_HOST
+  ? new NoyaAPI.NetworkClient({
+      baseURI: `${NOYA_HOST}/api`,
+    })
+  : undefined;
+
+function Content({ shareId }: { shareId: string }) {
+  const theme = useDesignSystemTheme();
+  const router = useRouter();
+
+  const [initialFile, setInitialFile] = useState<
+    NoyaAPI.SharedFile | undefined
+  >();
+  const [error, setError] = useState<Error | undefined>();
+
+  useEffect(() => {
+    async function main() {
+      if (!networkClient) return;
+
+      try {
+        const file = await networkClient.files.shares.readSharedFile(shareId);
+        setInitialFile(file);
+      } catch (error) {
+        if (error instanceof Error) {
+          setError(error);
+        }
+      }
+    }
+
+    main();
+  }, [shareId]);
+
+  if (error) {
+    return (
+      <Stack.V
+        flex="1"
+        alignItems="center"
+        justifyContent="center"
+        background={theme.colors.canvas.background}
+      >
+        <Stack.V
+          border={`1px solid ${theme.colors.dividerStrong}`}
+          padding={20}
+          background={theme.colors.sidebar.background}
+          maxWidth={300}
+        >
+          <Small color="text" fontWeight="bold">
+            Project not found
+          </Small>
+          <Spacer.Vertical size={4} />
+          <Small color="text">
+            This project may have been unshared. Contact the author to request
+            access.
+          </Small>
+          <Spacer.Vertical size={16} />
+          <Stack.H>
+            <Button variant="secondary" onClick={() => router.push('/')}>
+              Home
+              <Spacer.Horizontal size={6} inline />
+              <ArrowRightIcon />
+            </Button>
+          </Stack.H>
+        </Stack.V>
+      </Stack.V>
+    );
+  }
+
+  if (!initialFile) {
+    return null;
+  }
+
+  return (
+    <Ayon
+      fileId={shareId}
+      canvasRendererType="svg"
+      initialDocument={initialFile.data.document}
+      name={initialFile.data.name}
+      uploadAsset={async () => ''}
+      viewType="previewOnly"
+    />
+  );
+}
+
+function OptionalNoyaAPIProvider({ children }: { children: React.ReactNode }) {
+  const [client, setClient] = useState<NoyaAPI.Client | undefined>();
+
+  useEffect(() => {
+    async function main() {
+      try {
+        if (!networkClient) return;
+        await networkClient.auth.session();
+        setClient(createNoyaClient());
+      } catch {
+        // Ignore
+      }
+    }
+
+    main();
+  }, []);
+
+  if (client) {
+    return (
+      <NoyaAPIProvider value={client}>
+        <Analytics>{children}</Analytics>
+      </NoyaAPIProvider>
+    );
+  } else {
+    return <>{children}</>;
+  }
+}
+
+export default function Preview() {
+  const { query } = useRouter();
+  const shareId = query.shareId as string | undefined;
+
+  if (!shareId) return null;
+
+  addShareCookie(shareId);
+
+  return (
+    <OptionalNoyaAPIProvider>
+      <DesignSystemConfigurationProvider platform="key" theme={lightTheme}>
+        <Content shareId={shareId} />
+      </DesignSystemConfigurationProvider>
+    </OptionalNoyaAPIProvider>
+  );
+}


### PR DESCRIPTION
We call the API again on the client to get the fileId because during server-side rendering, the server is not authenticated as the user so fileId is never returned. If we want to remove that extra API call, networkClient could pass through the cookie header when server-side rendering.

This also creates a preview endpoint for the share, which is used for the Open Graph screenshot image.