### PR TITLE
Update logo

### DIFF
--- a/packages/site/src/components/Logo.tsx
+++ b/packages/site/src/components/Logo.tsx
@@ -5,41 +5,38 @@ export const Logo = forwardRef(function Logo(
   props: React.ComponentProps<'svg'>,
   ref: React.Ref<SVGSVGElement>,
 ) {
-  const { fill, highlight } = useDesignSystemTheme().colors.logo;
+  const { fill } = useDesignSystemTheme().colors.logo;
 
   return (
     <svg
       ref={ref}
       width="24"
-      height="24"
-      viewBox="0 0 24 24"
+      height="26"
+      viewBox="0 0 24 26"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path
-        d="M6.5 2H2V11H5V5H6.5C7.32843 5 8 5.67157 8 6.5V11H11V6.5C11 4.01472 8.98528 2 6.5 2Z"
+        d="M6.5 3H2V12H5V6H6.5C7.32843 6 8 6.67157 8 7.5V12H11V7.5C11 5.01472 8.98528 3 6.5 3Z"
         fill={fill}
       />
-      <rect x="2" y="2" width="3" height="3" fill={highlight} />
       <path
         fillRule="evenodd"
         clipRule="evenodd"
-        d="M17.5 11C19.9853 11 22 8.98528 22 6.5C22 4.01472 19.9853 2 17.5 2C15.0147 2 13 4.01472 13 6.5C13 8.98528 15.0147 11 17.5 11ZM17.5 8C18.3284 8 19 7.32843 19 6.5C19 5.67157 18.3284 5 17.5 5C16.6716 5 16 5.67157 16 6.5C16 7.32843 16.6716 8 17.5 8Z"
+        d="M17.5 12C19.9853 12 22 9.98528 22 7.5C22 5.01472 19.9853 3 17.5 3C15.0147 3 13 5.01472 13 7.5C13 9.98528 15.0147 12 17.5 12ZM17.5 9C18.3284 9 19 8.32843 19 7.5C19 6.67157 18.3284 6 17.5 6C16.6716 6 16 6.67157 16 7.5C16 8.32843 16.6716 9 17.5 9Z"
         fill={fill}
       />
       <path
-        d="M5 13H2V17.5C2 19.9853 4.01472 22 6.5 22H8V24H11V16H8V19H6.5C5.67157 19 5 18.3284 5 17.5V13Z"
+        d="M5 14H2V18.5C2 20.9853 4.01472 23 6.5 23H8V26H11V17H8V20H6.5C5.67157 20 5 19.3284 5 18.5V14Z"
         fill={fill}
       />
-      <rect x="2" y="13" width="3" height="3" fill={highlight} />
       <path
         fillRule="evenodd"
         clipRule="evenodd"
-        d="M17.5 22C15.0147 22 13 19.9853 13 17.5C13 15.0147 15.0147 13 17.5 13C19.9853 13 22 15.0147 22 17.5V22H17.5ZM17.5 19C18.3284 19 19 18.3284 19 17.5C19 16.6716 18.3284 16 17.5 16C16.6716 16 16 16.6716 16 17.5C16 18.3284 16.6716 19 17.5 19Z"
+        d="M17.5 23C15.0147 23 13 20.9853 13 18.5C13 16.0147 15.0147 14 17.5 14C19.9853 14 22 16.0147 22 18.5V23H17.5ZM17.5 20C18.3284 20 19 19.3284 19 18.5C19 17.6716 18.3284 17 17.5 17C16.6716 17 16 17.6716 16 18.5C16 19.3284 16.6716 20 17.5 20Z"
         fill={fill}
       />
-      <rect x="19" y="19" width="3" height="3" fill={highlight} />
     </svg>
   );
 });


### PR DESCRIPTION
This updates the logo to match the extended Y version as used on the website and elsewhere.

Here's a screenshot comparing them in use:
![image](https://user-images.githubusercontent.com/21080/217789191-3d6b1a6c-08d4-4567-a906-505461d33fdf.png)
